### PR TITLE
chore(matrix-synapse): bump to 0.1.5 to fix duplicate release tag

### DIFF
--- a/charts/matrix-synapse/Chart.yaml
+++ b/charts/matrix-synapse/Chart.yaml
@@ -3,7 +3,7 @@ name: matrix-synapse
 description: Matrix Synapse homeserver Helm chart
 type: application
 
-version: 0.1.4
+version: 0.1.5
 appVersion: "1.116.0"
 
 home: "https://github.com/matrix-org/synapse"

--- a/charts/matrix-synapse/README.md
+++ b/charts/matrix-synapse/README.md
@@ -1,6 +1,6 @@
 # matrix-synapse
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.116.0](https://img.shields.io/badge/AppVersion-1.116.0-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.116.0](https://img.shields.io/badge/AppVersion-1.116.0-informational?style=flat-square)
 
 Matrix Synapse homeserver Helm chart
 


### PR DESCRIPTION
PR #113 and #114 both used version 0.1.4, causing the chart-releaser to fail on the second merge. This PR bumps to 0.1.5 so the release can publish cleanly. No functional changes.