### PR TITLE
fix(mqtt-broker): mount passwd secret and use Recreate strategy (0.1.3)

### DIFF
--- a/charts/mqtt-broker/Chart.yaml
+++ b/charts/mqtt-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mqtt-broker
 description: A Helm chart for Eclipse Mosquitto
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "2.0.18"
 home: https://mosquitto.org/
 icon: https://cdn2.steamgriddb.com/icon/d17892563a6984845a0e23df7841f903/32/256x256.png

--- a/charts/mqtt-broker/templates/deployment.yaml
+++ b/charts/mqtt-broker/templates/deployment.yaml
@@ -7,6 +7,10 @@ spec:
   selector:
     matchLabels:
       app: mosquitto
+  {{- if .Values.persistence.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
   template:
     metadata:
       labels:
@@ -28,8 +32,17 @@ spec:
               mountPath: /mosquitto/data
       volumes:
         - name: config
+          {{- if .Values.auth.enabled }}
+          projected:
+            sources:
+              - configMap:
+                  name: mosquitto-config
+              - secret:
+                  name: {{ .Values.auth.existingSecret | default "mqtt-auth" }}
+          {{- else }}
           configMap:
             name: mosquitto-config
+          {{- end }}
         - name: data
           persistentVolumeClaim:
             claimName: mosquitto-data


### PR DESCRIPTION
## Summary
- **Bug**: `deployment.yaml` only mounted the configmap at `/mosquitto/config` — the `mosquitto-passwords` secret was never projected in, so mosquitto crashed with `Unable to open pwfile "/mosquitto/config/passwd"`
- **Fix**: When `auth.enabled`, use a projected volume combining the configmap (`mosquitto.conf`) + the secret (`passwd`) at `/mosquitto/config`
- **Fix**: Set `strategy.type: Recreate` when `persistence.enabled` to avoid RWO PVC contention during rolling updates

## Test plan
- [ ] Merge PR → chart 0.1.3 published
- [ ] Update `mqtt-broker.yaml` targetRevision to `0.1.3`
- [ ] ArgoCD sync → mosquitto pod starts clean, no CrashLoopBackOff
- [ ] Verify zigbee2mqtt and home-assistant can connect to MQTT

🤖 Generated with [Claude Code](https://claude.com/claude-code)