### PR TITLE
capi-cluster 0.0.88: per-MD kubeadmconfig, v1beta2 MHC, k8s 1.35 defaults

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.87
+version: 0.0.88
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "1.33"
+appVersion: "1.35"
 home: https://github.com/janip81/helm-charts/tree/main/charts/capi-cluster
 icon: https://raw.githubusercontent.com/janip81/helm-charts/artifacthub/logos/capi-logo.svg
 keywords:

--- a/charts/capi-cluster/templates/KubeadmConfigTemplate.yaml
+++ b/charts/capi-cluster/templates/KubeadmConfigTemplate.yaml
@@ -1,9 +1,10 @@
+{{- range .Values.machineDeployments }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
-  name: "{{ .Values.cluster.name }}-kubeadmconfig"
-  namespace: {{ .Values.cluster.name }}
+  name: "{{ $.Values.cluster.name }}-{{ .name }}-kubeadmconfig"
+  namespace: {{ $.Values.cluster.name }}
 spec:
   template:
     spec:
@@ -13,19 +14,19 @@ spec:
           kubeletExtraArgs:
             - name: cloud-provider
               value: external
-            {{- if .Values.cluster.bgpPolicyVlan }}
+            {{- if $.Values.cluster.bgpPolicyVlan }}
             - name: node-labels
-              value: "bgp-policy={{ .Values.cluster.bgpPolicyVlan }}"
+              value: "bgp-policy={{ $.Values.cluster.bgpPolicyVlan }}"
             {{- end }}
           name: {{ printf "'{{ local_hostname }}'" }}
-{{- if .taints }}
+          {{- if .taints }}
           taints:
-{{- range .taints }}
+          {{- range .taints }}
             - key: "{{ .key }}"
               value: "{{ .value }}"
               effect: "{{ .effect }}"
-{{- end }}
-{{- end }}
+          {{- end }}
+          {{- end }}
       preKubeadmCommands:
       - hostnamectl set-hostname {{ printf "'{{ ds.meta_data.hostname }}'" }}
       - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
@@ -38,5 +39,6 @@ spec:
       users:
       - name: capv
         sshAuthorizedKeys:
-        - {{ .Values.node.sshAuthorizedKeys }}
+        - {{ $.Values.node.sshAuthorizedKeys }}
         sudo: ALL=(ALL) NOPASSWD:ALL
+{{- end }}

--- a/charts/capi-cluster/templates/KubeadmControlPlane.yaml
+++ b/charts/capi-cluster/templates/KubeadmControlPlane.yaml
@@ -50,8 +50,6 @@ spec:
         kubeletExtraArgs:
           - name: cloud-provider
             value: external
-          - name: pod-infra-container-image
-            value: registry.k8s.io/pause:3.10
         name: {{ printf "'{{ local_hostname }}'" }}
     joinConfiguration:
       nodeRegistration:

--- a/charts/capi-cluster/templates/MachineDeployment.yaml
+++ b/charts/capi-cluster/templates/MachineDeployment.yaml
@@ -41,7 +41,7 @@ spec:
         configRef:
           apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
-          name: {{ $.Values.cluster.name }}-kubeadmconfig
+          name: {{ $.Values.cluster.name }}-{{ .name }}-kubeadmconfig
       clusterName: {{ $.Values.cluster.name }}
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io

--- a/charts/capi-cluster/templates/MachineHealthCheck.yaml
+++ b/charts/capi-cluster/templates/MachineHealthCheck.yaml
@@ -4,37 +4,39 @@ apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineHealthCheck
 metadata:
   name: {{ $.Values.cluster.name }}-{{ .name }}-unhealthy-5m
+  namespace: {{ $.Values.cluster.name }}
 spec:
   clusterName: {{ $.Values.cluster.name }}
+  maxUnhealthy: {{ $.Values.healthChecks.workernodes.maxUnhealthy }}
+  nodeStartupTimeout: "{{ $.Values.healthChecks.workernodes.nodeStartupTimeoutSeconds }}s"
   selector:
     matchLabels:
       cluster.x-k8s.io/deployment-name: {{ $.Values.cluster.name }}-{{ .name }}
-  checks:
-    nodeStartupTimeoutSeconds: {{ $.Values.healthChecks.workernodes.nodeStartupTimeoutSeconds }}
-    unhealthyNodeConditions:
-      - type: Ready
-        status: Unknown
-        timeoutSeconds: {{ $.Values.healthChecks.workernodes.unhealthyTimeoutUnknown }}
-      - type: Ready
-        status: "False"
-        timeoutSeconds: {{ $.Values.healthChecks.workernodes.unhealthyTimeoutFalse }}
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: "{{ $.Values.healthChecks.workernodes.unhealthyTimeoutUnknown }}s"
+    - type: Ready
+      status: "False"
+      timeout: "{{ $.Values.healthChecks.workernodes.unhealthyTimeoutFalse }}s"
 {{- end }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineHealthCheck
 metadata:
   name: {{ .Values.cluster.name }}-{{ .Values.healthChecks.controlplane.name }}
+  namespace: {{ .Values.cluster.name }}
 spec:
   clusterName: {{ .Values.cluster.name }}
+  maxUnhealthy: {{ .Values.healthChecks.controlplane.maxUnhealthy }}
+  nodeStartupTimeout: "{{ .Values.healthChecks.controlplane.nodeStartupTimeoutSeconds }}s"
   selector:
     matchLabels:
       cluster.x-k8s.io/control-plane: ""
-  checks:
-    nodeStartupTimeoutSeconds: {{ .Values.healthChecks.controlplane.nodeStartupTimeoutSeconds }}
-    unhealthyNodeConditions:
-      - type: Ready
-        status: Unknown
-        timeoutSeconds: {{ .Values.healthChecks.controlplane.unhealthyTimeoutUnknown }}
-      - type: Ready
-        status: "False"
-        timeoutSeconds: {{ .Values.healthChecks.controlplane.unhealthyTimeoutFalse }}
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: "{{ .Values.healthChecks.controlplane.unhealthyTimeoutUnknown }}s"
+    - type: Ready
+      status: "False"
+      timeout: "{{ .Values.healthChecks.controlplane.unhealthyTimeoutFalse }}s"

--- a/charts/capi-cluster/values.yaml
+++ b/charts/capi-cluster/values.yaml
@@ -39,7 +39,7 @@ gatewayapi:
 
 node:
   datastore: SSD01
-  template: ubuntu-2404-kube-v1.33.0
+  template: ubuntu-2404-kube-v1.35.0
   sshAuthorizedKeys: PublicKey
 
 vsphere:
@@ -56,14 +56,14 @@ vsphere:
     zone: zone
 
 controlPlaneNodes:
-  k8sVersion: 1.33.0
-  vspehereMachineTemplate: ubnt2204-2cpu-4g-128
+  k8sVersion: 1.35.0
+  vspehereMachineTemplate: ubnt2204-2cpu-4g-135
   replicas: 3
 
 machineDeployments:
   - name: md-0
-    vspehereMachineTemplate: ubnt2204-4cpu-8g-128
-    k8sVersion: 1.33.0
+    vspehereMachineTemplate: ubnt2204-4cpu-8g-135
+    k8sVersion: 1.35.0
     replicas: 2
     # Add additonal labels to nodes
     nodeLabels:
@@ -79,13 +79,13 @@ machineDeployments:
       autoscaler: enabled
 
     # Add annotations to your machine deployments for example if you have autoscaler
-    machideDeploymentAnnotations:
+    machineDeploymentAnnotations:
       # cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
       # cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "0"
 
   - name: md-1
-    vspehereMachineTemplate: ubnt2204-4cpu-8g-133
-    k8sVersion: 1.33.0
+    vspehereMachineTemplate: ubnt2204-4cpu-8g-135
+    k8sVersion: 1.35.0
     replicas: 3
     # Add additonal labels to nodes
     nodeLabels:
@@ -96,7 +96,7 @@ machineDeployments:
       # cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "0"
 
     # Add annotations to your nodes for example if you have autoscaler
-    machideDeploymentAnnotations:
+    machineDeploymentAnnotations:
       cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
       cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "0"
     taints:
@@ -112,7 +112,7 @@ machineTemplates:
     # linkedClone or fullClone , linkedClone is faster but but cant extend disk beyound template size
     cloneMode: FullClone
     diskSize: 25
-    isoTemplate: ubuntu-2404-kube-v1.33.0
+    isoTemplate: ubuntu-2404-kube-v1.35.0
     vcenterDatastore: SSD01
     vcenterFolder:
     network: vcenterNetwork
@@ -123,7 +123,7 @@ machineTemplates:
     # linkedClone or fullClone , linkedClone is faster but but cant extend disk beyound template size
     cloneMode: FullClone
     diskSize: 35
-    isoTemplate: ubuntu-2404-kube-v1.33.0
+    isoTemplate: ubuntu-2404-kube-v1.35.0
     vcenterDatastore: SSD01
     vcenterFolder:
     network: vcenterNetwork

--- a/charts/mqtt-broker/Chart.yaml
+++ b/charts/mqtt-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mqtt-broker
 description: A Helm chart for Eclipse Mosquitto
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "2.0.18"
 home: https://mosquitto.org/
 icon: https://cdn2.steamgriddb.com/icon/d17892563a6984845a0e23df7841f903/32/256x256.png

--- a/charts/mqtt-broker/README.md
+++ b/charts/mqtt-broker/README.md
@@ -1,6 +1,6 @@
 # mqtt-broker
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.18](https://img.shields.io/badge/AppVersion-2.0.18-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.18](https://img.shields.io/badge/AppVersion-2.0.18-informational?style=flat-square)
 
 A Helm chart for Eclipse Mosquitto
 


### PR DESCRIPTION
## Summary

- **Fix: taint support was silently broken** — `KubeadmConfigTemplate` was a single shared resource; the `{{- if .taints }}` block was at root scope where `.taints` is always nil. Now one template is created per `MachineDeployment`, so per-MD taints (e.g. `dedicated=pci:NoSchedule`) are correctly written into `nodeRegistration.taints`
- **MachineDeployment** references the per-MD kubeadmconfig (`<cluster>-<md-name>-kubeadmconfig`)
- **KubeadmControlPlane** removes deprecated `pod-infra-container-image` kubelet arg (deprecated since k8s 1.31)
- **MachineHealthCheck** updated to v1beta2 field names: `spec.nodeStartupTimeout` (duration string), `spec.unhealthyConditions`, `spec.maxUnhealthy` at spec level; `namespace` added to metadata
- **values.yaml** defaults bumped to k8s 1.35.0 / `ubuntu-2404-kube-v1.35.0`; `machideDeploymentAnnotations` typo fixed

## Impact on existing clusters

| Change | Effect |
|--------|--------|
| Per-MD KubeadmConfigTemplate (new name) | New resources created; old shared one orphaned (prune:false — safe) |
| MachineDeployment references new configRef | Workers rolling restart to pick up new template |
| KCP removes pod-infra-container-image | CP nodes rolling restart |
| MachineHealthCheck field names | In-place update, no disruption |

## Test plan

- [ ] Merge PR → GitHub Pages CI publishes chart `0.0.88`
- [ ] Update dev-k8s `targetRevision: 0.0.88` in k8s-gitops → sync `cluster-dev-k8s` in ArgoCD
- [ ] Verify per-MD KubeadmConfigTemplates created, old shared one orphaned
- [ ] Verify workers roll and come back Ready
- [ ] Verify CP rolls (pod-infra-container-image removal)
- [ ] Verify pci-node taint `dedicated=pci:NoSchedule` appears on node after upgrade to 0.0.88