### PR TITLE
capi-cluster 0.0.89: fix MachineHealthCheck schema for CAPI v1.11.3

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.88
+version: 0.0.89
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/MachineHealthCheck.yaml
+++ b/charts/capi-cluster/templates/MachineHealthCheck.yaml
@@ -7,18 +7,18 @@ metadata:
   namespace: {{ $.Values.cluster.name }}
 spec:
   clusterName: {{ $.Values.cluster.name }}
-  maxUnhealthy: {{ $.Values.healthChecks.workernodes.maxUnhealthy }}
-  nodeStartupTimeout: "{{ $.Values.healthChecks.workernodes.nodeStartupTimeoutSeconds }}s"
   selector:
     matchLabels:
       cluster.x-k8s.io/deployment-name: {{ $.Values.cluster.name }}-{{ .name }}
-  unhealthyConditions:
-    - type: Ready
-      status: Unknown
-      timeout: "{{ $.Values.healthChecks.workernodes.unhealthyTimeoutUnknown }}s"
-    - type: Ready
-      status: "False"
-      timeout: "{{ $.Values.healthChecks.workernodes.unhealthyTimeoutFalse }}s"
+  checks:
+    nodeStartupTimeoutSeconds: {{ $.Values.healthChecks.workernodes.nodeStartupTimeoutSeconds }}
+    unhealthyNodeConditions:
+      - type: Ready
+        status: Unknown
+        timeoutSeconds: {{ $.Values.healthChecks.workernodes.unhealthyTimeoutUnknown }}
+      - type: Ready
+        status: "False"
+        timeoutSeconds: {{ $.Values.healthChecks.workernodes.unhealthyTimeoutFalse }}
 {{- end }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta2
@@ -28,15 +28,15 @@ metadata:
   namespace: {{ .Values.cluster.name }}
 spec:
   clusterName: {{ .Values.cluster.name }}
-  maxUnhealthy: {{ .Values.healthChecks.controlplane.maxUnhealthy }}
-  nodeStartupTimeout: "{{ .Values.healthChecks.controlplane.nodeStartupTimeoutSeconds }}s"
   selector:
     matchLabels:
       cluster.x-k8s.io/control-plane: ""
-  unhealthyConditions:
-    - type: Ready
-      status: Unknown
-      timeout: "{{ .Values.healthChecks.controlplane.unhealthyTimeoutUnknown }}s"
-    - type: Ready
-      status: "False"
-      timeout: "{{ .Values.healthChecks.controlplane.unhealthyTimeoutFalse }}s"
+  checks:
+    nodeStartupTimeoutSeconds: {{ .Values.healthChecks.controlplane.nodeStartupTimeoutSeconds }}
+    unhealthyNodeConditions:
+      - type: Ready
+        status: Unknown
+        timeoutSeconds: {{ .Values.healthChecks.controlplane.unhealthyTimeoutUnknown }}
+      - type: Ready
+        status: "False"
+        timeoutSeconds: {{ .Values.healthChecks.controlplane.unhealthyTimeoutFalse }}


### PR DESCRIPTION
## Summary

- Fix `MachineHealthCheck` template — `spec.maxUnhealthy`, `spec.nodeStartupTimeout` (duration string), and `spec.unhealthyConditions` are **not declared** in the v1beta2 schema for CAPI v1.11.3 (confirmed against live CRD)
- Revert to the correct `spec.checks` structure: `nodeStartupTimeoutSeconds` (int) and `unhealthyNodeConditions` with `timeoutSeconds` (int)
- Namespace in metadata is kept (was missing before 0.0.88)

## Root cause

Assumed v1beta2 MachineHealthCheck had moved fields to spec-level (based on upstream docs), but CAPI v1.11.3 still uses the `spec.checks` sub-object. The actual spec fields are: `checks`, `clusterName`, `remediation`, `selector`.

## Test plan

- [ ] PR CI passes
- [ ] Merge → 0.0.89 published
- [ ] Update dev-k8s targetRevision to 0.0.89, sync ArgoCD → no schema error