### PR TITLE
capi-cluster: 0.0.90 — kubelet image GC configuration

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.89
+version: 0.0.90
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/KubeadmConfigTemplate.yaml
+++ b/charts/capi-cluster/templates/KubeadmConfigTemplate.yaml
@@ -27,6 +27,10 @@ spec:
               effect: "{{ .effect }}"
           {{- end }}
           {{- end }}
+      kubeletConfiguration:
+        imageGCHighThresholdPercent: {{ $.Values.kubelet.imageGCHighThresholdPercent }}
+        imageGCLowThresholdPercent: {{ $.Values.kubelet.imageGCLowThresholdPercent }}
+        imageMaximumGCAge: {{ $.Values.kubelet.imageMaximumGCAge }}
       preKubeadmCommands:
       - hostnamectl set-hostname {{ printf "'{{ ds.meta_data.hostname }}'" }}
       - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"

--- a/charts/capi-cluster/templates/KubeadmControlPlane.yaml
+++ b/charts/capi-cluster/templates/KubeadmControlPlane.yaml
@@ -58,6 +58,10 @@ spec:
           - name: cloud-provider
             value: external
         name: {{ printf "'{{ local_hostname }}'" }}
+    kubeletConfiguration:
+      imageGCHighThresholdPercent: {{ .Values.kubelet.imageGCHighThresholdPercent }}
+      imageGCLowThresholdPercent: {{ .Values.kubelet.imageGCLowThresholdPercent }}
+      imageMaximumGCAge: {{ .Values.kubelet.imageMaximumGCAge }}
     preKubeadmCommands:
       - hostnamectl set-hostname {{ printf "'{{ ds.meta_data.hostname }}'" }}
       - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6" > /etc/hosts

--- a/charts/capi-cluster/values.yaml
+++ b/charts/capi-cluster/values.yaml
@@ -137,6 +137,11 @@ machineTemplates:
       pciPassthru2.msiEnabled: "TRUE"
       pciPassthru3.msiEnabled: "TRUE"
 
+kubelet:
+  imageGCHighThresholdPercent: 70
+  imageGCLowThresholdPercent: 65
+  imageMaximumGCAge: 168h0m0s
+
 kubeVIP:
   image:
     repository: ghcr.io/kube-vip/kube-vip


### PR DESCRIPTION
## Summary

- Adds `kubeletConfiguration` block to both `KubeadmControlPlane` and `KubeadmConfigTemplate`
- Configurable via `kubelet:` in chart values, with sensible defaults
- Defaults: `imageGCHighThresholdPercent: 70`, `imageGCLowThresholdPercent: 65`, `imageMaximumGCAge: 168h0m0s`

Without this, kubelet defaults to 85% threshold with no age-based cleanup — images accumulate until the disk is nearly full before GC kicks in.

## Test plan

- [ ] Deploy 0.0.90 on dev-k8s, verify `kubelet-config` ConfigMap in kube-system reflects the new settings
- [ ] Confirm new nodes provisioned by CAPI pick up the kubelet GC config
- [ ] Promote to prod-k8s after dev-k8s confirms healthy