### PR TITLE
capi-cluster: 0.0.91 — fix kubelet image GC via kubeletExtraArgs

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.90
+version: 0.0.91
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/KubeadmConfigTemplate.yaml
+++ b/charts/capi-cluster/templates/KubeadmConfigTemplate.yaml
@@ -14,6 +14,12 @@ spec:
           kubeletExtraArgs:
             - name: cloud-provider
               value: external
+            - name: image-gc-high-threshold
+              value: {{ $.Values.kubelet.imageGCHighThresholdPercent | quote }}
+            - name: image-gc-low-threshold
+              value: {{ $.Values.kubelet.imageGCLowThresholdPercent | quote }}
+            - name: image-maximum-gc-age
+              value: {{ $.Values.kubelet.imageMaximumGCAge | quote }}
             {{- if $.Values.cluster.bgpPolicyVlan }}
             - name: node-labels
               value: "bgp-policy={{ $.Values.cluster.bgpPolicyVlan }}"
@@ -27,10 +33,6 @@ spec:
               effect: "{{ .effect }}"
           {{- end }}
           {{- end }}
-      kubeletConfiguration:
-        imageGCHighThresholdPercent: {{ $.Values.kubelet.imageGCHighThresholdPercent }}
-        imageGCLowThresholdPercent: {{ $.Values.kubelet.imageGCLowThresholdPercent }}
-        imageMaximumGCAge: {{ $.Values.kubelet.imageMaximumGCAge }}
       preKubeadmCommands:
       - hostnamectl set-hostname {{ printf "'{{ ds.meta_data.hostname }}'" }}
       - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"

--- a/charts/capi-cluster/templates/KubeadmControlPlane.yaml
+++ b/charts/capi-cluster/templates/KubeadmControlPlane.yaml
@@ -50,6 +50,12 @@ spec:
         kubeletExtraArgs:
           - name: cloud-provider
             value: external
+          - name: image-gc-high-threshold
+            value: {{ .Values.kubelet.imageGCHighThresholdPercent | quote }}
+          - name: image-gc-low-threshold
+            value: {{ .Values.kubelet.imageGCLowThresholdPercent | quote }}
+          - name: image-maximum-gc-age
+            value: {{ .Values.kubelet.imageMaximumGCAge | quote }}
         name: {{ printf "'{{ local_hostname }}'" }}
     joinConfiguration:
       nodeRegistration:
@@ -57,11 +63,13 @@ spec:
         kubeletExtraArgs:
           - name: cloud-provider
             value: external
+          - name: image-gc-high-threshold
+            value: {{ .Values.kubelet.imageGCHighThresholdPercent | quote }}
+          - name: image-gc-low-threshold
+            value: {{ .Values.kubelet.imageGCLowThresholdPercent | quote }}
+          - name: image-maximum-gc-age
+            value: {{ .Values.kubelet.imageMaximumGCAge | quote }}
         name: {{ printf "'{{ local_hostname }}'" }}
-    kubeletConfiguration:
-      imageGCHighThresholdPercent: {{ .Values.kubelet.imageGCHighThresholdPercent }}
-      imageGCLowThresholdPercent: {{ .Values.kubelet.imageGCLowThresholdPercent }}
-      imageMaximumGCAge: {{ .Values.kubelet.imageMaximumGCAge }}
     preKubeadmCommands:
       - hostnamectl set-hostname {{ printf "'{{ ds.meta_data.hostname }}'" }}
       - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6" > /etc/hosts


### PR DESCRIPTION
## Summary

Fixes broken 0.0.90 — `kubeletConfiguration` is not declared in the installed CAPI CRD schema, causing ArgoCD diff failure.

Switch to `kubeletExtraArgs` flags instead:
- `image-gc-high-threshold`
- `image-gc-low-threshold`
- `image-maximum-gc-age`

Applied to `initConfiguration` and `joinConfiguration` in `KubeadmControlPlane`, and `joinConfiguration` in `KubeadmConfigTemplate`. Values remain configurable via `kubelet:` in chart values.

## Test plan

- [ ] ArgoCD syncs dev-k8s without diff error
- [ ] New nodes show kubelet flags in `/var/lib/kubelet/config.yaml`