### PR TITLE
capi-cluster: 0.0.92 — fix kubelet image GC via drop-in config file

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.91
+version: 0.0.92
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/KubeadmConfigTemplate.yaml
+++ b/charts/capi-cluster/templates/KubeadmConfigTemplate.yaml
@@ -14,12 +14,8 @@ spec:
           kubeletExtraArgs:
             - name: cloud-provider
               value: external
-            - name: image-gc-high-threshold
-              value: {{ $.Values.kubelet.imageGCHighThresholdPercent | quote }}
-            - name: image-gc-low-threshold
-              value: {{ $.Values.kubelet.imageGCLowThresholdPercent | quote }}
-            - name: image-maximum-gc-age
-              value: {{ $.Values.kubelet.imageMaximumGCAge | quote }}
+            - name: config-dir
+              value: /etc/kubernetes/kubelet.conf.d
             {{- if $.Values.cluster.bgpPolicyVlan }}
             - name: node-labels
               value: "bgp-policy={{ $.Values.cluster.bgpPolicyVlan }}"
@@ -40,8 +36,19 @@ spec:
       - echo "127.0.0.1   {{ printf "{{ ds.meta_data.hostname }} {{ local_hostname }}" }} localhost
         localhost.localdomain localhost4 localhost4.localdomain4" >>/etc/hosts
       - mkdir -p /etc/pre-kubeadm-commands
+      - mkdir -p /etc/kubernetes/kubelet.conf.d
       - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort);
         do echo "Running script $script"; "$script"; done
+      files:
+      - content: |
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          kind: KubeletConfiguration
+          imageGCHighThresholdPercent: {{ $.Values.kubelet.imageGCHighThresholdPercent }}
+          imageGCLowThresholdPercent: {{ $.Values.kubelet.imageGCLowThresholdPercent }}
+          imageMaximumGCAge: "{{ $.Values.kubelet.imageMaximumGCAge }}"
+        owner: root:root
+        path: /etc/kubernetes/kubelet.conf.d/10-gc.conf
+        permissions: "0644"
       users:
       - name: capv
         sshAuthorizedKeys:

--- a/charts/capi-cluster/templates/KubeadmControlPlane.yaml
+++ b/charts/capi-cluster/templates/KubeadmControlPlane.yaml
@@ -50,12 +50,8 @@ spec:
         kubeletExtraArgs:
           - name: cloud-provider
             value: external
-          - name: image-gc-high-threshold
-            value: {{ .Values.kubelet.imageGCHighThresholdPercent | quote }}
-          - name: image-gc-low-threshold
-            value: {{ .Values.kubelet.imageGCLowThresholdPercent | quote }}
-          - name: image-maximum-gc-age
-            value: {{ .Values.kubelet.imageMaximumGCAge | quote }}
+          - name: config-dir
+            value: /etc/kubernetes/kubelet.conf.d
         name: {{ printf "'{{ local_hostname }}'" }}
     joinConfiguration:
       nodeRegistration:
@@ -63,18 +59,15 @@ spec:
         kubeletExtraArgs:
           - name: cloud-provider
             value: external
-          - name: image-gc-high-threshold
-            value: {{ .Values.kubelet.imageGCHighThresholdPercent | quote }}
-          - name: image-gc-low-threshold
-            value: {{ .Values.kubelet.imageGCLowThresholdPercent | quote }}
-          - name: image-maximum-gc-age
-            value: {{ .Values.kubelet.imageMaximumGCAge | quote }}
+          - name: config-dir
+            value: /etc/kubernetes/kubelet.conf.d
         name: {{ printf "'{{ local_hostname }}'" }}
     preKubeadmCommands:
       - hostnamectl set-hostname {{ printf "'{{ ds.meta_data.hostname }}'" }}
       - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6" > /etc/hosts
       - echo "127.0.0.1   {{ printf "{{ ds.meta_data.hostname }} {{ local_hostname }}" }} localhost localhost.localdomain localhost4 localhost4.localdomain4" >> /etc/hosts
       - mkdir -p /etc/pre-kubeadm-commands
+      - mkdir -p /etc/kubernetes/kubelet.conf.d
       - for script in $(find /etc/pre-kubeadm-commands/ -name '*.sh' -type f | sort); do echo "Running script $script"; "$script"; done
     files:
       - content: |
@@ -152,6 +145,15 @@ spec:
       - content: 127.0.0.1 localhost kubernetes
         owner: root:root
         path: /etc/kube-vip.hosts
+        permissions: "0644"
+      - content: |
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          kind: KubeletConfiguration
+          imageGCHighThresholdPercent: {{ .Values.kubelet.imageGCHighThresholdPercent }}
+          imageGCLowThresholdPercent: {{ .Values.kubelet.imageGCLowThresholdPercent }}
+          imageMaximumGCAge: "{{ .Values.kubelet.imageMaximumGCAge }}"
+        owner: root:root
+        path: /etc/kubernetes/kubelet.conf.d/10-gc.conf
         permissions: "0644"
       - content: |
           #!/bin/bash


### PR DESCRIPTION
## Summary

- Deprecated kubelet CLI flags (`image-gc-high-threshold`, `image-gc-low-threshold`, `image-maximum-gc-age`) were removed in k8s 1.35 and silently dropped by kubeadm, so GC settings were never applied
- Replace with proper KubeletConfiguration drop-in file at `/etc/kubernetes/kubelet.conf.d/10-gc.conf`
- Add `--config-dir=/etc/kubernetes/kubelet.conf.d` to `kubeletExtraArgs` so kubelet picks up the drop-in
- `mkdir -p /etc/kubernetes/kubelet.conf.d` added to `preKubeadmCommands` as safety guard
- Affects both KubeadmControlPlane (init + join) and KubeadmConfigTemplate (worker join)

## Test plan
- [ ] Merge PR, update dev-k8s to 0.0.92, roll a node, verify `/etc/kubernetes/kubelet.conf.d/10-gc.conf` exists and `imageGCHighThresholdPercent: 70` is active in kubelet