### PR TITLE
capi-cluster 0.0.93 — kubelet image GC fix + etcd defrag CronJob

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.92
+version: 0.0.93
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/Cluster.yaml
+++ b/charts/capi-cluster/templates/Cluster.yaml
@@ -11,6 +11,9 @@ metadata:
     {{ $addonConfig.name }}: enabled
     {{- end }}
     {{- end }}
+    {{- if .Values.etcdDefrag.enabled }}
+    etcd-defrag: enabled
+    {{- end }}
 spec:
   clusterNetwork:
     pods:

--- a/charts/capi-cluster/templates/EtcdDefrag.yaml
+++ b/charts/capi-cluster/templates/EtcdDefrag.yaml
@@ -1,0 +1,120 @@
+{{- define "etcd-defrag.manifest" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-defrag
+  namespace: kube-system
+automountServiceAccountToken: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-defrag
+  namespace: kube-system
+spec:
+  schedule: {{ .Values.etcdDefrag.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.etcdDefrag.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.etcdDefrag.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: etcd-defrag
+          hostNetwork: true
+          restartPolicy: OnFailure
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              effect: NoSchedule
+          volumes:
+            - name: etcd-certs
+              hostPath:
+                path: /etc/kubernetes/pki/etcd
+                type: Directory
+          containers:
+            - name: etcd-defrag
+              image: {{ .Values.etcdDefrag.image | default (include "etcd.image" .) | quote }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  CACERT=/etc/kubernetes/pki/etcd/ca.crt
+                  CERT=/etc/kubernetes/pki/etcd/server.crt
+                  KEY=/etc/kubernetes/pki/etcd/server.key
+                  LOCAL=https://127.0.0.1:2379
+                  E="etcdctl --cacert=$CACERT --cert=$CERT --key=$KEY --command-timeout=120s"
+
+                  # Discover all member client URLs from local etcd
+                  ENDPOINTS=$($E --endpoints=$LOCAL member list --write-out=fields \
+                    | awk '/ClientURL/{print $3}' | paste -sd,)
+                  echo "Members: $ENDPOINTS"
+
+                  echo "=== Pre-defrag status ==="
+                  $E --endpoints=$ENDPOINTS endpoint status --write-out=table
+
+                  echo "=== Compacting ==="
+                  REV=$($E --endpoints=$LOCAL endpoint status --write-out=json \
+                    | tr ',' '\n' | grep '"revision"' | head -1 | tr -cd '0-9')
+                  echo "Compact revision: $REV"
+                  $E --endpoints=$LOCAL compact "$REV"
+
+                  echo "=== Defragging followers first ==="
+                  for EP in $(echo "$ENDPOINTS" | tr ',' ' '); do
+                    IS_LEADER=$($E --endpoints=$EP endpoint status --write-out=fields \
+                      | grep IsLeader | awk '{print $3}')
+                    if [ "$IS_LEADER" = "false" ]; then
+                      echo "Defragging follower: $EP"
+                      $E --endpoints=$EP defrag
+                    fi
+                  done
+
+                  echo "=== Defragging leader ==="
+                  for EP in $(echo "$ENDPOINTS" | tr ',' ' '); do
+                    IS_LEADER=$($E --endpoints=$EP endpoint status --write-out=fields \
+                      | grep IsLeader | awk '{print $3}')
+                    if [ "$IS_LEADER" = "true" ]; then
+                      echo "Defragging leader: $EP"
+                      $E --endpoints=$EP defrag
+                    fi
+                  done
+
+                  echo "=== Post-defrag status ==="
+                  $E --endpoints=$ENDPOINTS endpoint status --write-out=table
+                  $E --endpoints=$ENDPOINTS endpoint health
+              volumeMounts:
+                - name: etcd-certs
+                  mountPath: /etc/kubernetes/pki/etcd
+                  readOnly: true
+{{- end }}
+{{- if .Values.etcdDefrag.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.cluster.name }}-etcd-defrag
+  namespace: {{ .Values.cluster.name }}
+  annotations:
+    argocd.argoproj.io/sync-options: "ControllerReferencesOnly=true"
+data:
+  resources.yaml: |
+{{ include "etcd-defrag.manifest" . | indent 4 }}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta2
+kind: ClusterResourceSet
+metadata:
+  name: {{ .Values.cluster.name }}-etcd-defrag
+  namespace: {{ .Values.cluster.name }}
+  annotations:
+    argocd.argoproj.io/sync-options: "ControllerReferencesOnly=true"
+spec:
+  clusterSelector:
+    matchLabels:
+      etcd-defrag: enabled
+  strategy: Reconcile
+  resources:
+    - name: {{ .Values.cluster.name }}-etcd-defrag
+      kind: ConfigMap
+{{- end }}

--- a/charts/capi-cluster/templates/_helpers.tpl
+++ b/charts/capi-cluster/templates/_helpers.tpl
@@ -3,3 +3,22 @@
 {{- define "worker.replicas" -}}
 {{- .replicas | default 1 }}
 {{- end }}
+
+{{/*
+etcd.image returns the etcd container image that matches the cluster's k8s minor version.
+Override by setting etcdDefrag.image in values.
+*/}}
+{{- define "etcd.image" -}}
+{{- $v := .Values.controlPlaneNodes.k8sVersion -}}
+{{- $parts := splitList "." $v -}}
+{{- $minor := index $parts 1 | int -}}
+{{- if eq $minor 35 -}}registry.k8s.io/etcd:3.6.6-0
+{{- else if eq $minor 34 -}}registry.k8s.io/etcd:3.6.4-0
+{{- else if eq $minor 33 -}}registry.k8s.io/etcd:3.5.21-0
+{{- else if eq $minor 32 -}}registry.k8s.io/etcd:3.5.16-0
+{{- else if eq $minor 31 -}}registry.k8s.io/etcd:3.5.15-0
+{{- else if eq $minor 30 -}}registry.k8s.io/etcd:3.5.12-0
+{{- else -}}
+{{- fail (printf "etcdDefrag: no known etcd image for k8s 1.%d — set etcdDefrag.image manually" $minor) -}}
+{{- end -}}
+{{- end }}

--- a/charts/capi-cluster/values.yaml
+++ b/charts/capi-cluster/values.yaml
@@ -199,3 +199,14 @@ addons:
           # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
           tag: ""
           pullPolicy: IfNotPresent
+
+# Periodic etcd compact + defrag job. Runs as a CronJob on a control-plane node.
+# Discovers etcd members dynamically — no IP configuration needed.
+# image is auto-selected from controlPlaneNodes.k8sVersion (supported: 1.30–1.35).
+# Override image only if auto-detection is wrong or you use a patched etcd build.
+etcdDefrag:
+  enabled: false
+  schedule: "0 3 * * 0"          # Sunday 03:00 UTC
+  image: ""                       # leave empty to auto-detect from k8s version
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Changes

**0.0.92 — kubelet image GC via drop-in config file**
- Replaces deprecated `kubeletExtraArgs` flags with a kubelet drop-in config file
- Fixes image garbage collection settings (`imageGCHighThresholdPercent`, `imageGCLowThresholdPercent`, `imageMaximumGCAge`) that were silently ignored in k8s 1.35

**0.0.93 — etcd compact + defrag CronJob**
- New `etcdDefrag.enabled` toggle (default: `false`)
- Deploys a `CronJob` + `ServiceAccount` into the workload cluster via `ClusterResourceSet`
- etcd image auto-resolved from `controlPlaneNodes.k8sVersion` (supported: 1.30–1.35); override with `etcdDefrag.image`
- Members discovered dynamically at runtime — no IPs in config
- Defrags followers first, then leader; `strategy: Reconcile` so ConfigMap updates propagate

## Usage

```yaml
etcdDefrag:
  enabled: true
  schedule: "0 3 * * 0"   # optional, default Sunday 03:00 UTC
  # image: ""              # leave empty — auto-detected from k8s version
```