### PR TITLE
capi-cluster: 0.0.93 + 0.0.94 — etcdDefrag CronJob + etcd 3.6.x fixes

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.93
+version: 0.0.94
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/EtcdDefrag.yaml
+++ b/charts/capi-cluster/templates/EtcdDefrag.yaml
@@ -22,12 +22,15 @@ spec:
         spec:
           serviceAccountName: etcd-defrag
           hostNetwork: true
+          hostPID: true             # needed to find etcd process via /proc
           restartPolicy: OnFailure
           nodeSelector:
             node-role.kubernetes.io/control-plane: ""
           tolerations:
             - key: node-role.kubernetes.io/control-plane
               effect: NoSchedule
+          securityContext:
+            runAsUser: 0            # root required to read /proc/<pid>/root/
           volumes:
             - name: etcd-certs
               hostPath:
@@ -35,21 +38,44 @@ spec:
                 type: Directory
           containers:
             - name: etcd-defrag
-              image: {{ .Values.etcdDefrag.image | default (include "etcd.image" .) | quote }}
+              # alpine: small base image with shell. etcdctl sourced from the running
+              # etcd container via /proc/<pid>/root so the binary always matches the
+              # server version — works for etcd 3.5.x (debian) and 3.6.x (distroless).
+              image: {{ .Values.etcdDefrag.image | default "alpine:3.21" | quote }}
               command:
                 - /bin/sh
                 - -c
                 - |
                   set -e
+
+                  # Find etcd binary via the running process — version-independent
+                  echo "=== Locating etcd process ==="
+                  ETCD_PID=""
+                  for exe in /proc/[0-9]*/exe; do
+                    target=$(readlink "$exe" 2>/dev/null) || continue
+                    case "$target" in
+                      */etcd) ETCD_PID=${exe%/exe}; ETCD_PID=${ETCD_PID#/proc/}; break ;;
+                    esac
+                  done
+
+                  if [ -z "$ETCD_PID" ]; then
+                    echo "ERROR: etcd process not found" >&2
+                    exit 1
+                  fi
+
+                  ETCDCTL="/proc/$ETCD_PID/root/usr/local/bin/etcdctl"
+                  echo "etcd PID: $ETCD_PID"
+                  echo "etcdctl version: $($ETCDCTL version 2>&1 | head -1)"
+
                   CACERT=/etc/kubernetes/pki/etcd/ca.crt
                   CERT=/etc/kubernetes/pki/etcd/server.crt
                   KEY=/etc/kubernetes/pki/etcd/server.key
                   LOCAL=https://127.0.0.1:2379
-                  E="etcdctl --cacert=$CACERT --cert=$CERT --key=$KEY --command-timeout=120s"
+                  E="$ETCDCTL --cacert=$CACERT --cert=$CERT --key=$KEY --command-timeout=120s"
 
-                  # Discover all member client URLs from local etcd
+                  # Discover all member endpoints — strip quotes added by etcd 3.6.x
                   ENDPOINTS=$($E --endpoints=$LOCAL member list --write-out=fields \
-                    | awk '/ClientURL/{print $3}' | paste -sd,)
+                    | awk '/ClientURL/{print $3}' | tr -d '"' | paste -sd,)
                   echo "Members: $ENDPOINTS"
 
                   echo "=== Pre-defrag status ==="
@@ -63,9 +89,10 @@ spec:
 
                   echo "=== Defragging followers first ==="
                   for EP in $(echo "$ENDPOINTS" | tr ',' ' '); do
-                    IS_LEADER=$($E --endpoints=$EP endpoint status --write-out=fields \
-                      | grep IsLeader | awk '{print $3}')
-                    if [ "$IS_LEADER" = "false" ]; then
+                    EP_STATUS=$($E --endpoints=$EP endpoint status --write-out=fields 2>/dev/null)
+                    LEADER_ID=$(echo "$EP_STATUS" | awk -F' : ' '/"Leader"/{print $2}' | tr -d ' "')
+                    MEMBER_ID=$(echo "$EP_STATUS" | awk -F' : ' '/"MemberID"/{print $2}' | tr -d ' "')
+                    if [ -n "$LEADER_ID" ] && [ "$LEADER_ID" != "$MEMBER_ID" ]; then
                       echo "Defragging follower: $EP"
                       $E --endpoints=$EP defrag
                     fi
@@ -73,9 +100,10 @@ spec:
 
                   echo "=== Defragging leader ==="
                   for EP in $(echo "$ENDPOINTS" | tr ',' ' '); do
-                    IS_LEADER=$($E --endpoints=$EP endpoint status --write-out=fields \
-                      | grep IsLeader | awk '{print $3}')
-                    if [ "$IS_LEADER" = "true" ]; then
+                    EP_STATUS=$($E --endpoints=$EP endpoint status --write-out=fields 2>/dev/null)
+                    LEADER_ID=$(echo "$EP_STATUS" | awk -F' : ' '/"Leader"/{print $2}' | tr -d ' "')
+                    MEMBER_ID=$(echo "$EP_STATUS" | awk -F' : ' '/"MemberID"/{print $2}' | tr -d ' "')
+                    if [ -n "$LEADER_ID" ] && [ "$LEADER_ID" = "$MEMBER_ID" ]; then
                       echo "Defragging leader: $EP"
                       $E --endpoints=$EP defrag
                     fi


### PR DESCRIPTION
## Summary

- **0.0.93**: Add etcdDefrag CronJob via ClusterResourceSet — auto-detects etcd image from k8s version, runs compact + defrag (followers first, leader last) on a weekly schedule
- **0.0.94**: Fix etcd 3.6.x compatibility (k8s 1.34+)

## 0.0.94 — etcd 3.6.x fixes

etcd 3.6.x images are distroless (no shell). Three breaking changes vs 3.5.x:

| Issue | Root cause | Fix |
|-------|-----------|-----|
| Container fails to start | Distroless image has no `/bin/sh` | Switch to `alpine:3.21`; source `etcdctl` from running etcd via `/proc/<pid>/root` |
| Member URLs parsed with literal quotes | etcd 3.6.x wraps URLs in `"..."` in fields output | Add `tr -d '"'` to endpoint list parsing |
| Defrag loops skip all nodes | `IsLeader` field dropped from `--write-out=fields` | Compare `"Leader"` ID vs `"MemberID"` ID instead |

The procfs approach (`/proc/<etcd-pid>/root/usr/local/bin/etcdctl`) sources the binary directly from the running etcd container — version-independent, works for both 3.5.x and 3.6.x.

## Test plan

- [x] Validated on dev-k8s (etcd 3.6.6, k8s 1.35): 95 MB → 6.1 MB after defrag
- [ ] Verify prod-k8s (etcd 3.5.x, k8s 1.33) still works after upgrade