### PR TITLE
feat: gameledger 0.1.1 — add secret.create toggle

### DIFF
--- a/charts/gameledger/Chart.yaml
+++ b/charts/gameledger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gameledger
 description: App to keep track of card and board game wins losses
 type: application
-version: "0.1.0"
+version: "0.1.1"
 appVersion: "0.1.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/gameledger
 # icon: https://www.home-assistant.io/images/favicon-192x192.png

--- a/charts/gameledger/README.md
+++ b/charts/gameledger/README.md
@@ -1,6 +1,6 @@
 # gameledger
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 App to keep track of card and board game wins losses
 
@@ -91,7 +91,8 @@ To uninstall the chart:
 | resources.limits.memory | string | `"512Mi"` |  |
 | resources.requests.cpu | string | `"50m"` |  |
 | resources.requests.memory | string | `"256Mi"` |  |
-| secretEnv | object | `{"DATABASE_URL":"changeme","SESSION_SECRET":"changeme"}` | Secret environment variables rendered via ArgoCD Vault Plugin Override in ArgoCD values with correct AVP paths |
+| secret | object | `{"create":true}` | Secret management. Set create: false when the secret is managed externally (e.g. AVP via cluster-config) |
+| secretEnv | object | `{"DATABASE_URL":"changeme","SESSION_SECRET":"changeme"}` | Secret environment variables rendered via ArgoCD Vault Plugin (only used when secret.create: true) |
 | service.annotations | object | `{}` |  |
 | service.port | int | `80` |  |
 | service.targetPort | int | `3000` |  |

--- a/charts/gameledger/templates/secret.yaml
+++ b/charts/gameledger/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +10,5 @@ type: Opaque
 stringData:
 {{- range $k, $v := .Values.secretEnv }}
   {{ $k }}: {{ $v | quote }}
+{{- end }}
 {{- end }}

--- a/charts/gameledger/values.yaml
+++ b/charts/gameledger/values.yaml
@@ -22,8 +22,11 @@ migrations:
 env:
   NODE_ENV: "production"
 
-# -- Secret environment variables rendered via ArgoCD Vault Plugin
-# Override in ArgoCD values with correct AVP paths
+# -- Secret management. Set create: false when the secret is managed externally (e.g. AVP via cluster-config)
+secret:
+  create: true
+
+# -- Secret environment variables rendered via ArgoCD Vault Plugin (only used when secret.create: true)
 secretEnv:
   DATABASE_URL: "changeme"
   SESSION_SECRET: "changeme"


### PR DESCRIPTION
## Summary
- Adds `secret.create: true/false` toggle to gameledger chart
- Set `false` when secret is managed externally via AVP cluster-config
- Fixes duplicate Secret resource error in ArgoCD multi-source setup
- Bumps chart to 0.1.1