### PR TITLE
fix: gameledger 0.1.2 — HTTPRoute v1

### DIFF
--- a/charts/gameledger/Chart.yaml
+++ b/charts/gameledger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gameledger
 description: App to keep track of card and board game wins losses
 type: application
-version: "0.1.1"
+version: "0.1.2"
 appVersion: "0.1.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/gameledger
 # icon: https://www.home-assistant.io/images/favicon-192x192.png

--- a/charts/gameledger/README.md
+++ b/charts/gameledger/README.md
@@ -1,6 +1,6 @@
 # gameledger
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 App to keep track of card and board game wins losses
 

--- a/charts/gameledger/templates/httproute.yaml
+++ b/charts/gameledger/templates/httproute.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gateway.enabled }}
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "gameledger.fullname" . }}


### PR DESCRIPTION
Fix HTTPRoute apiVersion from v1beta1 to v1 (required by Cilium Gateway API on this cluster).