### PR TITLE
feat: add unifi-network-application chart v0.1.0

### DIFF
--- a/charts/gameledger/Chart.yaml
+++ b/charts/gameledger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gameledger
 description: App to keep track of card and board game wins losses
 type: application
-version: "0.1.1"
+version: "0.1.2"
 appVersion: "0.1.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/gameledger
 # icon: https://www.home-assistant.io/images/favicon-192x192.png

--- a/charts/gameledger/README.md
+++ b/charts/gameledger/README.md
@@ -1,6 +1,6 @@
 # gameledger
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 App to keep track of card and board game wins losses
 

--- a/charts/gameledger/templates/httproute.yaml
+++ b/charts/gameledger/templates/httproute.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gateway.enabled }}
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "gameledger.fullname" . }}

--- a/charts/unifi-network-application/Chart.yaml
+++ b/charts/unifi-network-application/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: unifi-network-application
+description: Helm chart for the UniFi Network Application (WiFi controller)
+type: application
+version: "0.1.0"
+appVersion: "stable"
+home: https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application
+icon: https://prd-www-cdn.ubnt.com/static/favicon-152.png
+maintainers:
+  - name: janip81
+    email: jani@techmonkeys.se
+    url: https://github.com/janip81
+keywords:
+  - unifi
+  - ubiquiti
+  - wifi
+sources:
+  - https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application/
+  - https://github.com/jacobalberty/unifi-docker
+deprecated: false
+annotations:
+  artifacthub.io/links: |
+    - name: Chart source
+      url: https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application/

--- a/charts/unifi-network-application/LICENSE
+++ b/charts/unifi-network-application/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/unifi-network-application/NOTES.txt
+++ b/charts/unifi-network-application/NOTES.txt
@@ -1,0 +1,11 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+The UniFi Network Application is accessible on the LoadBalancer service for device management.
+Web UI: https://<LOADBALANCER-IP>:8443
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -63,6 +63,7 @@ Helm's [documentation](https://helm.sh/docs) to get started.
 | env.TZ | string | `"Europe/Stockholm"` | Timezone for the controller |
 | env.UNIFI_GID | string | `"999"` | GID the application runs as |
 | env.UNIFI_UID | string | `"999"` | UID the application runs as |
+| fullnameOverride | string | `""` | Override the full name of all resources (service, deployment, pvc). Recommended: set to a short name like "unifi" |
 | httproute.annotations | object | `{"argocd.argoproj.io/sync-options":"SkipDryRunOnMissingResource=true"}` | Annotations for the HTTPRoute |
 | httproute.enabled | bool | `false` | Enable HTTPRoute for the web UI |
 | httproute.gatewayName | string | `"internal-shared"` | Gateway name to attach the HTTPRoute to |

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -1,0 +1,92 @@
+# unifi-network-application
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: stable](https://img.shields.io/badge/AppVersion-stable-informational?style=flat-square)
+
+Helm chart for the UniFi Network Application (WiFi controller)
+
+**Homepage:** <https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| janip81 | <jani@techmonkeys.se> | <https://github.com/janip81> |
+
+## Source Code
+
+* <https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application/>
+* <https://github.com/jacobalberty/unifi-docker>
+
+# Overview
+Helm chart for the UniFi Network Application (WiFi controller) using the `jacobalberty/unifi` image,
+which bundles MongoDB and the controller in a single container.
+
+Includes:
+- A **ClusterIP** service for the HTTPS web UI (port 8443)
+- A **LoadBalancer** service for UniFi device communication (8080/TCP, 3478/UDP, 10001/UDP)
+- Optional **HTTPRoute** for Cilium Gateway API (disabled by default — requires BackendTLSPolicy for HTTPS backend)
+
+## Adding this helm repository
+
+To add the helm repository, run the following commands:
+
+```bash
+helm repo add janip81 https://janip81.github.io/helm-charts/
+helm search repo unifi-network-application
+```
+
+`values.yaml` files for the charts can be found in the `charts/[chartname]` directories.
+
+## TL;DR
+
+```bash
+helm repo add janip81 https://janip81.github.io/helm-charts/
+helm install my-unifi janip81/unifi-network-application -f YOUR-OWN-VALUES.yaml
+```
+
+[Helm](https://helm.sh) must be installed to use the charts. Please refer to
+Helm's [documentation](https://helm.sh/docs) to get started.
+
+## Prerequisites
+
+- [Kubernetes](https://kubernetes.io/)
+- [Helm 3.1.0](https://helm.sh)
+- PV provisioner support in the underlying infrastructure (for persistent storage)
+- LoadBalancer support in the underlying infrastructure (for device communication)
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod scheduling |
+| deviceService.annotations | object | `{}` | Annotations for the device service (e.g. for MetalLB/Cilium IP pool selection) |
+| deviceService.enabled | bool | `true` | Enable the LoadBalancer service for UniFi device communication |
+| deviceService.ports | list | `[{"name":"controller","port":8080,"protocol":"TCP"},{"name":"stun","port":3478,"protocol":"UDP"},{"name":"discovery","port":10001,"protocol":"UDP"}]` | Ports exposed for device communication |
+| deviceService.type | string | `"LoadBalancer"` | Service type for device communication |
+| env.JVM_MAX_HEAP_SIZE | string | `"1024M"` | JVM maximum heap size. Increase for larger installations |
+| env.RUNAS_UID0 | string | `"false"` | Run as root (set to "true" only if required) |
+| env.TZ | string | `"Europe/Stockholm"` | Timezone for the controller |
+| env.UNIFI_GID | string | `"999"` | GID the application runs as |
+| env.UNIFI_UID | string | `"999"` | UID the application runs as |
+| httproute.annotations | object | `{"argocd.argoproj.io/sync-options":"SkipDryRunOnMissingResource=true"}` | Annotations for the HTTPRoute |
+| httproute.enabled | bool | `false` | Enable HTTPRoute via Cilium Gateway API. Note: UniFi serves HTTPS only (port 8443). Requires a BackendTLSPolicy to connect to the backend over TLS. Enable only after creating a ConfigMap 'unifi-ca' with key 'ca.crt' containing the controller's CA certificate. |
+| httproute.gatewayName | string | `"internal-shared"` | Gateway name to attach the HTTPRoute to |
+| httproute.gatewayNamespace | string | `"kube-system"` | Namespace of the gateway |
+| httproute.hostname | string | `"unifi.mgmt.threshold.se"` | Hostname for the HTTPRoute |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"jacobalberty/unifi"` | Docker registry/repository to pull the image from |
+| image.tag | string | `"stable"` | Image tag. Uses `stable` by default; pin to a specific version (e.g. `v9.0.108`) for production |
+| nodeSelector | object | `{}` | Node selector for pod scheduling |
+| persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the PVC |
+| persistence.enabled | bool | `true` | Enable persistent storage for UniFi data |
+| persistence.size | string | `"5Gi"` | Size of the PVC |
+| persistence.storageClass | string | `""` | Storage class name. Leave empty to use the cluster default |
+| podSecurityContext | object | `{"fsGroup":999}` | Pod security context |
+| resources | object | `{"limits":{"cpu":"1000m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"512Mi"}}` | Resource requests and limits |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":false,"runAsGroup":999,"runAsNonRoot":true,"runAsUser":999}` | Container security context |
+| service.port | int | `8443` | Service port |
+| service.type | string | `"ClusterIP"` | Service type for the web UI (HTTPS port 8443) |
+| tolerations | list | `[]` | Tolerations for pod scheduling |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -22,8 +22,7 @@ Helm chart for the UniFi Network Application (WiFi controller) using the `jacoba
 which bundles MongoDB and the controller in a single container.
 
 Includes:
-- A **ClusterIP** service for the HTTPS web UI (port 8443)
-- A **LoadBalancer** service for UniFi device communication (8080/TCP, 3478/UDP, 10001/UDP)
+- A single **LoadBalancer** service exposing all required ports: HTTPS web UI (8443/TCP), AP device communication (8080/TCP), STUN (3478/UDP), L2 discovery (10001/UDP), speed test (6789/TCP)
 - Optional **HTTPRoute** for Cilium Gateway API (disabled by default — requires BackendTLSPolicy for HTTPS backend)
 
 ## Adding this helm repository
@@ -59,17 +58,13 @@ Helm's [documentation](https://helm.sh/docs) to get started.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for pod scheduling |
-| deviceService.annotations | object | `{}` | Annotations for the device service (e.g. for MetalLB/Cilium IP pool selection) |
-| deviceService.enabled | bool | `true` | Enable the LoadBalancer service for UniFi device communication |
-| deviceService.ports | list | `[{"name":"controller","port":8080,"protocol":"TCP"},{"name":"stun","port":3478,"protocol":"UDP"},{"name":"discovery","port":10001,"protocol":"UDP"}]` | Ports exposed for device communication |
-| deviceService.type | string | `"LoadBalancer"` | Service type for device communication |
 | env.JVM_MAX_HEAP_SIZE | string | `"1024M"` | JVM maximum heap size. Increase for larger installations |
 | env.RUNAS_UID0 | string | `"false"` | Run as root (set to "true" only if required) |
 | env.TZ | string | `"Europe/Stockholm"` | Timezone for the controller |
 | env.UNIFI_GID | string | `"999"` | GID the application runs as |
 | env.UNIFI_UID | string | `"999"` | UID the application runs as |
 | httproute.annotations | object | `{"argocd.argoproj.io/sync-options":"SkipDryRunOnMissingResource=true"}` | Annotations for the HTTPRoute |
-| httproute.enabled | bool | `false` | Enable HTTPRoute via Cilium Gateway API. Note: UniFi serves HTTPS only (port 8443). Requires a BackendTLSPolicy to connect to the backend over TLS. Enable only after creating a ConfigMap 'unifi-ca' with key 'ca.crt' containing the controller's CA certificate. |
+| httproute.enabled | bool | `false` | Enable HTTPRoute for the web UI |
 | httproute.gatewayName | string | `"internal-shared"` | Gateway name to attach the HTTPRoute to |
 | httproute.gatewayNamespace | string | `"kube-system"` | Namespace of the gateway |
 | httproute.hostname | string | `"unifi.mgmt.threshold.se"` | Hostname for the HTTPRoute |
@@ -84,8 +79,9 @@ Helm's [documentation](https://helm.sh/docs) to get started.
 | podSecurityContext | object | `{"fsGroup":999}` | Pod security context |
 | resources | object | `{"limits":{"cpu":"1000m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"512Mi"}}` | Resource requests and limits |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":false,"runAsGroup":999,"runAsNonRoot":true,"runAsUser":999}` | Container security context |
-| service.port | int | `8443` | Service port |
-| service.type | string | `"ClusterIP"` | Service type for the web UI (HTTPS port 8443) |
+| service.annotations | object | `{}` | Annotations for the service (e.g. for Cilium IP pool selection) |
+| service.ports | list | `[{"name":"http","port":8443,"protocol":"TCP"},{"name":"controller","port":8080,"protocol":"TCP"},{"name":"stun","port":3478,"protocol":"UDP"},{"name":"discovery","port":10001,"protocol":"UDP"},{"name":"speedtest","port":6789,"protocol":"TCP"}]` | Ports exposed by the service. All ports required for full UniFi AP management are included by default. 8443/TCP: HTTPS web UI 8080/TCP: AP device communication (inform) 3478/UDP: STUN (required for AP tunnelling and provisioning) 10001/UDP: L2 device discovery (works only on same broadcast domain) 6789/TCP: UniFi mobile speed test (optional) |
+| service.type | string | `"LoadBalancer"` | Service type. LoadBalancer is required so both the web UI and AP device communication ports are reachable from outside the cluster. |
 | tolerations | list | `[]` | Tolerations for pod scheduling |
 
 ----------------------------------------------

--- a/charts/unifi-network-application/README.md.gotmpl
+++ b/charts/unifi-network-application/README.md.gotmpl
@@ -1,0 +1,55 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+# Overview
+Helm chart for the UniFi Network Application (WiFi controller) using the `jacobalberty/unifi` image,
+which bundles MongoDB and the controller in a single container.
+
+Includes:
+- A **ClusterIP** service for the HTTPS web UI (port 8443)
+- A **LoadBalancer** service for UniFi device communication (8080/TCP, 3478/UDP, 10001/UDP)
+- Optional **HTTPRoute** for Cilium Gateway API (disabled by default — requires BackendTLSPolicy for HTTPS backend)
+
+## Adding this helm repository
+
+To add the helm repository, run the following commands:
+
+```bash
+helm repo add janip81 https://janip81.github.io/helm-charts/
+helm search repo unifi-network-application
+```
+
+`values.yaml` files for the charts can be found in the `charts/[chartname]` directories.
+
+## TL;DR
+
+```bash
+helm repo add janip81 https://janip81.github.io/helm-charts/
+helm install my-unifi janip81/unifi-network-application -f YOUR-OWN-VALUES.yaml
+```
+
+[Helm](https://helm.sh) must be installed to use the charts. Please refer to
+Helm's [documentation](https://helm.sh/docs) to get started.
+
+## Prerequisites
+
+- [Kubernetes](https://kubernetes.io/)
+- [Helm 3.1.0](https://helm.sh)
+- PV provisioner support in the underlying infrastructure (for persistent storage)
+- LoadBalancer support in the underlying infrastructure (for device communication)
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/unifi-network-application/README.md.gotmpl
+++ b/charts/unifi-network-application/README.md.gotmpl
@@ -16,8 +16,7 @@ Helm chart for the UniFi Network Application (WiFi controller) using the `jacoba
 which bundles MongoDB and the controller in a single container.
 
 Includes:
-- A **ClusterIP** service for the HTTPS web UI (port 8443)
-- A **LoadBalancer** service for UniFi device communication (8080/TCP, 3478/UDP, 10001/UDP)
+- A single **LoadBalancer** service exposing all required ports: HTTPS web UI (8443/TCP), AP device communication (8080/TCP), STUN (3478/UDP), L2 discovery (10001/UDP), speed test (6789/TCP)
 - Optional **HTTPRoute** for Cilium Gateway API (disabled by default — requires BackendTLSPolicy for HTTPS backend)
 
 ## Adding this helm repository

--- a/charts/unifi-network-application/templates/_helpers.tpl
+++ b/charts/unifi-network-application/templates/_helpers.tpl
@@ -5,7 +5,11 @@
 {{- end }}
 
 {{- define "unifi-network-application.fullname" -}}
-{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{- define "unifi-network-application.labels" -}}

--- a/charts/unifi-network-application/templates/_helpers.tpl
+++ b/charts/unifi-network-application/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "unifi-network-application.name" -}}
+{{- .Chart.Name -}}
+{{- end }}
+
+{{- define "unifi-network-application.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "unifi-network-application.labels" -}}
+app.kubernetes.io/name: {{ include "unifi-network-application.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "unifi-network-application.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "unifi-network-application.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/unifi-network-application/templates/deployment.yaml
+++ b/charts/unifi-network-application/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "unifi-network-application.fullname" . }}
+  labels:
+    {{- include "unifi-network-application.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "unifi-network-application.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "unifi-network-application.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: unifi-network-application
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8443
+              protocol: TCP
+            - name: controller
+              containerPort: 8080
+              protocol: TCP
+            - name: stun
+              containerPort: 3478
+              protocol: UDP
+            - name: discovery
+              containerPort: 10001
+              protocol: UDP
+          env:
+            - name: TZ
+              value: {{ .Values.env.TZ | quote }}
+            - name: RUNAS_UID0
+              value: {{ .Values.env.RUNAS_UID0 | quote }}
+            - name: UNIFI_UID
+              value: {{ .Values.env.UNIFI_UID | quote }}
+            - name: UNIFI_GID
+              value: {{ .Values.env.UNIFI_GID | quote }}
+            - name: JVM_MAX_HEAP_SIZE
+              value: {{ .Values.env.JVM_MAX_HEAP_SIZE | quote }}
+          volumeMounts:
+            - name: data
+              mountPath: /unifi
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /status
+              port: 8443
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /status
+              port: 8443
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "unifi-network-application.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/unifi-network-application/templates/httproute.yaml
+++ b/charts/unifi-network-application/templates/httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.httproute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "unifi-network-application.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    - name: {{ .Values.httproute.gatewayName }}
+      namespace: {{ .Values.httproute.gatewayNamespace }}
+      group: gateway.networking.k8s.io
+      kind: Gateway
+  hostnames:
+    - {{ .Values.httproute.hostname }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "unifi-network-application.fullname" . }}
+          kind: Service
+          port: {{ .Values.service.port }}
+          weight: 1
+{{- end }}

--- a/charts/unifi-network-application/templates/httproute.yaml
+++ b/charts/unifi-network-application/templates/httproute.yaml
@@ -24,6 +24,6 @@ spec:
       backendRefs:
         - name: {{ include "unifi-network-application.fullname" . }}
           kind: Service
-          port: {{ .Values.service.port }}
+          port: 8443
           weight: 1
 {{- end }}

--- a/charts/unifi-network-application/templates/pvc.yaml
+++ b/charts/unifi-network-application/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "unifi-network-application.fullname" . }}
+  labels:
+    {{- include "unifi-network-application.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/unifi-network-application/templates/service.yaml
+++ b/charts/unifi-network-application/templates/service.yaml
@@ -4,31 +4,14 @@ metadata:
   name: {{ include "unifi-network-application.fullname" . }}
   labels:
     {{- include "unifi-network-application.labels" . | nindent 4 }}
-spec:
-  type: {{ .Values.service.type }}
-  ports:
-    - name: http
-      port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-  selector:
-    {{- include "unifi-network-application.selectorLabels" . | nindent 4 }}
-{{- if .Values.deviceService.enabled }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "unifi-network-application.fullname" . }}-devices
-  labels:
-    {{- include "unifi-network-application.labels" . | nindent 4 }}
-  {{- with .Values.deviceService.annotations }}
+  {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.deviceService.type }}
+  type: {{ .Values.service.type }}
   ports:
-    {{- range .Values.deviceService.ports }}
+    {{- range .Values.service.ports }}
     - name: {{ .name }}
       port: {{ .port }}
       targetPort: {{ .name }}
@@ -36,4 +19,3 @@ spec:
     {{- end }}
   selector:
     {{- include "unifi-network-application.selectorLabels" . | nindent 4 }}
-{{- end }}

--- a/charts/unifi-network-application/templates/service.yaml
+++ b/charts/unifi-network-application/templates/service.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "unifi-network-application.fullname" . }}
+  labels:
+    {{- include "unifi-network-application.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "unifi-network-application.selectorLabels" . | nindent 4 }}
+{{- if .Values.deviceService.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "unifi-network-application.fullname" . }}-devices
+  labels:
+    {{- include "unifi-network-application.labels" . | nindent 4 }}
+  {{- with .Values.deviceService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.deviceService.type }}
+  ports:
+    {{- range .Values.deviceService.ports }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .name }}
+      protocol: {{ .protocol }}
+    {{- end }}
+  selector:
+    {{- include "unifi-network-application.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/unifi-network-application/values.yaml
+++ b/charts/unifi-network-application/values.yaml
@@ -1,5 +1,8 @@
 # Default values for unifi-network-application.
 
+# -- Override the full name of all resources (service, deployment, pvc). Recommended: set to a short name like "unifi"
+fullnameOverride: ""
+
 image:
   # -- Docker registry/repository to pull the image from
   repository: jacobalberty/unifi

--- a/charts/unifi-network-application/values.yaml
+++ b/charts/unifi-network-application/values.yaml
@@ -43,20 +43,22 @@ persistence:
   size: 5Gi
 
 service:
-  # -- Service type for the web UI (HTTPS port 8443)
-  type: ClusterIP
-  # -- Service port
-  port: 8443
-
-deviceService:
-  # -- Enable the LoadBalancer service for UniFi device communication
-  enabled: true
-  # -- Service type for device communication
+  # -- Service type. LoadBalancer is required so both the web UI and AP device
+  # communication ports are reachable from outside the cluster.
   type: LoadBalancer
-  # -- Annotations for the device service (e.g. for MetalLB/Cilium IP pool selection)
+  # -- Annotations for the service (e.g. for Cilium IP pool selection)
   annotations: {}
-  # -- Ports exposed for device communication
+  # -- Ports exposed by the service.
+  # All ports required for full UniFi AP management are included by default.
+  # 8443/TCP: HTTPS web UI
+  # 8080/TCP: AP device communication (inform)
+  # 3478/UDP: STUN (required for AP tunnelling and provisioning)
+  # 10001/UDP: L2 device discovery (works only on same broadcast domain)
+  # 6789/TCP: UniFi mobile speed test (optional)
   ports:
+    - name: http
+      port: 8443
+      protocol: TCP
     - name: controller
       port: 8080
       protocol: TCP
@@ -66,12 +68,17 @@ deviceService:
     - name: discovery
       port: 10001
       protocol: UDP
+    - name: speedtest
+      port: 6789
+      protocol: TCP
 
+# HTTPRoute via Cilium Gateway API for the web UI.
+# Note: UniFi serves HTTPS only (port 8443). The gateway needs a BackendTLSPolicy
+# to connect to the HTTPS backend. Enable only after extracting the controller CA
+# cert and creating a ConfigMap 'unifi-ca' with key 'ca.crt' in this namespace.
+# Until then, access the UI directly at https://<LoadBalancer-IP>:8443
 httproute:
-  # -- Enable HTTPRoute via Cilium Gateway API.
-  # Note: UniFi serves HTTPS only (port 8443). Requires a BackendTLSPolicy to connect
-  # to the backend over TLS. Enable only after creating a ConfigMap 'unifi-ca' with
-  # key 'ca.crt' containing the controller's CA certificate.
+  # -- Enable HTTPRoute for the web UI
   enabled: false
   # -- Gateway name to attach the HTTPRoute to
   gatewayName: internal-shared

--- a/charts/unifi-network-application/values.yaml
+++ b/charts/unifi-network-application/values.yaml
@@ -1,0 +1,73 @@
+image:
+  repository: jacobalberty/unifi
+  tag: "stable"
+  pullPolicy: IfNotPresent
+
+env:
+  TZ: "Europe/Stockholm"
+  RUNAS_UID0: "false"
+  UNIFI_UID: "999"
+  UNIFI_GID: "999"
+  JVM_MAX_HEAP_SIZE: "1024M"
+
+podSecurityContext:
+  fsGroup: 999
+
+securityContext:
+  runAsUser: 999
+  runAsGroup: 999
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+
+persistence:
+  enabled: true
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 5Gi
+
+# ClusterIP service for the web UI (HTTPS port 8443)
+service:
+  type: ClusterIP
+  port: 8443
+
+# LoadBalancer service for UniFi device communication.
+# UniFi APs need to reach the controller on these ports.
+deviceService:
+  enabled: true
+  type: LoadBalancer
+  annotations: {}
+  ports:
+    - name: controller
+      port: 8080
+      protocol: TCP
+    - name: stun
+      port: 3478
+      protocol: UDP
+    - name: discovery
+      port: 10001
+      protocol: UDP
+
+# HTTPRoute via Cilium Gateway API.
+# Note: UniFi serves HTTPS only (port 8443). The gateway needs a BackendTLSPolicy
+# to connect to the backend over TLS. Enable only after extracting the controller's
+# CA cert and creating a ConfigMap 'unifi-ca' with key 'ca.crt' in this namespace.
+httproute:
+  enabled: false
+  gatewayName: internal-shared
+  gatewayNamespace: kube-system
+  hostname: unifi.mgmt.threshold.se
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+resources:
+  requests:
+    memory: 512Mi
+    cpu: 100m
+  limits:
+    memory: 1024Mi
+    cpu: 1000m
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/unifi-network-application/values.yaml
+++ b/charts/unifi-network-application/values.yaml
@@ -1,18 +1,30 @@
+# Default values for unifi-network-application.
+
 image:
+  # -- Docker registry/repository to pull the image from
   repository: jacobalberty/unifi
+  # -- Image tag. Uses `stable` by default; pin to a specific version (e.g. `v9.0.108`) for production
   tag: "stable"
+  # -- Image pull policy
   pullPolicy: IfNotPresent
 
 env:
+  # -- Timezone for the controller
   TZ: "Europe/Stockholm"
+  # -- Run as root (set to "true" only if required)
   RUNAS_UID0: "false"
+  # -- UID the application runs as
   UNIFI_UID: "999"
+  # -- GID the application runs as
   UNIFI_GID: "999"
+  # -- JVM maximum heap size. Increase for larger installations
   JVM_MAX_HEAP_SIZE: "1024M"
 
+# -- Pod security context
 podSecurityContext:
   fsGroup: 999
 
+# -- Container security context
 securityContext:
   runAsUser: 999
   runAsGroup: 999
@@ -21,22 +33,29 @@ securityContext:
   runAsNonRoot: true
 
 persistence:
+  # -- Enable persistent storage for UniFi data
   enabled: true
+  # -- Storage class name. Leave empty to use the cluster default
   storageClass: ""
+  # -- Access mode for the PVC
   accessMode: ReadWriteOnce
+  # -- Size of the PVC
   size: 5Gi
 
-# ClusterIP service for the web UI (HTTPS port 8443)
 service:
+  # -- Service type for the web UI (HTTPS port 8443)
   type: ClusterIP
+  # -- Service port
   port: 8443
 
-# LoadBalancer service for UniFi device communication.
-# UniFi APs need to reach the controller on these ports.
 deviceService:
+  # -- Enable the LoadBalancer service for UniFi device communication
   enabled: true
+  # -- Service type for device communication
   type: LoadBalancer
+  # -- Annotations for the device service (e.g. for MetalLB/Cilium IP pool selection)
   annotations: {}
+  # -- Ports exposed for device communication
   ports:
     - name: controller
       port: 8080
@@ -48,18 +67,23 @@ deviceService:
       port: 10001
       protocol: UDP
 
-# HTTPRoute via Cilium Gateway API.
-# Note: UniFi serves HTTPS only (port 8443). The gateway needs a BackendTLSPolicy
-# to connect to the backend over TLS. Enable only after extracting the controller's
-# CA cert and creating a ConfigMap 'unifi-ca' with key 'ca.crt' in this namespace.
 httproute:
+  # -- Enable HTTPRoute via Cilium Gateway API.
+  # Note: UniFi serves HTTPS only (port 8443). Requires a BackendTLSPolicy to connect
+  # to the backend over TLS. Enable only after creating a ConfigMap 'unifi-ca' with
+  # key 'ca.crt' containing the controller's CA certificate.
   enabled: false
+  # -- Gateway name to attach the HTTPRoute to
   gatewayName: internal-shared
+  # -- Namespace of the gateway
   gatewayNamespace: kube-system
+  # -- Hostname for the HTTPRoute
   hostname: unifi.mgmt.threshold.se
+  # -- Annotations for the HTTPRoute
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
+# -- Resource requests and limits
 resources:
   requests:
     memory: 512Mi
@@ -68,6 +92,9 @@ resources:
     memory: 1024Mi
     cpu: 1000m
 
+# -- Node selector for pod scheduling
 nodeSelector: {}
+# -- Tolerations for pod scheduling
 tolerations: []
+# -- Affinity rules for pod scheduling
 affinity: {}

--- a/ct-install-skip.yaml
+++ b/ct-install-skip.yaml
@@ -7,4 +7,5 @@ excluded-charts:
   - worklog
   - castlist
   - gameledger
+  - unifi-network-application
 helm-extra-args: "--values ci/common-ct-values.yaml --timeout 15m --wait"


### PR DESCRIPTION
## Summary

- New chart for UniFi Network Application using `jacobalberty/unifi` image (bundles MongoDB)
- Single `LoadBalancer` service exposing all AP management ports: 8443/TCP (UI), 8080/TCP (device inform), 3478/UDP (STUN), 10001/UDP (L2 discovery), 6789/TCP (speed test)
- Optional HTTPRoute support via Cilium Gateway API (disabled by default — HTTPS backend requires BackendTLSPolicy)
- `fullnameOverride` support for predictable resource naming
- helm-docs generated README included

## Test plan

- [ ] Chart publishes to `janip81.github.io/helm-charts` via CI
- [ ] `helm template` renders without errors
- [ ] ArgoCD Application deploys to prod-mgmt `unifi` namespace
- [ ] LoadBalancer gets IP from Cilium BGP pool
- [ ] AP can reach controller on 8080/TCP and 3478/UDP