### PR TITLE
feat: unifi-network-application 0.2.0 — linuxserver + bundled MongoDB

### DIFF
--- a/charts/unifi-network-application/Chart.yaml
+++ b/charts/unifi-network-application/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: unifi-network-application
 description: Helm chart for the UniFi Network Application (WiFi controller)
 type: application
-version: "0.1.0"
-appVersion: "stable"
+version: "0.2.0"
+appVersion: "10.3.55"
 home: https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application
 icon: https://prd-www-cdn.ubnt.com/static/favicon-152.png
 maintainers:

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -1,6 +1,6 @@
 # unifi-network-application
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: stable](https://img.shields.io/badge/AppVersion-stable-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
 
 Helm chart for the UniFi Network Application (WiFi controller)
 
@@ -22,7 +22,10 @@ Helm chart for the UniFi Network Application (WiFi controller) using the `jacoba
 which bundles MongoDB and the controller in a single container.
 
 Includes:
+- **linuxserver/unifi-network-application** container (actively maintained, tracks latest UniFi releases)
+- **Bundled MongoDB 7.0** deployment (no external database required)
 - A single **LoadBalancer** service exposing all required ports: HTTPS web UI (8443/TCP), AP device communication (8080/TCP), STUN (3478/UDP), L2 discovery (10001/UDP), speed test (6789/TCP)
+- Init container that waits for MongoDB before starting the controller
 - Optional **HTTPRoute** for Cilium Gateway API (disabled by default — requires BackendTLSPolicy for HTTPS backend)
 
 ## Adding this helm repository
@@ -58,31 +61,41 @@ Helm's [documentation](https://helm.sh/docs) to get started.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for pod scheduling |
-| env.JVM_MAX_HEAP_SIZE | string | `"1024M"` | JVM maximum heap size. Increase for larger installations |
-| env.RUNAS_UID0 | string | `"false"` | Run as root (set to "true" only if required) |
-| env.TZ | string | `"Europe/Stockholm"` | Timezone for the controller |
-| env.UNIFI_GID | string | `"999"` | GID the application runs as |
-| env.UNIFI_UID | string | `"999"` | UID the application runs as |
-| fullnameOverride | string | `""` | Override the full name of all resources (service, deployment, pvc). Recommended: set to a short name like "unifi" |
+| env.PGID | string | `"1000"` | Group ID the application runs as |
+| env.PUID | string | `"1000"` | User ID the application runs as |
+| env.TZ | string | `"Europe/Stockholm"` | Timezone |
+| fullnameOverride | string | `""` | Override the full name of all resources. Recommended: set to a short name like "unifi" |
 | httproute.annotations | object | `{"argocd.argoproj.io/sync-options":"SkipDryRunOnMissingResource=true"}` | Annotations for the HTTPRoute |
 | httproute.enabled | bool | `false` | Enable HTTPRoute for the web UI |
-| httproute.gatewayName | string | `"internal-shared"` | Gateway name to attach the HTTPRoute to |
-| httproute.gatewayNamespace | string | `"kube-system"` | Namespace of the gateway |
+| httproute.gatewayName | string | `"internal-shared"` | Gateway name |
+| httproute.gatewayNamespace | string | `"kube-system"` | Gateway namespace |
 | httproute.hostname | string | `"unifi.mgmt.threshold.se"` | Hostname for the HTTPRoute |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"jacobalberty/unifi"` | Docker registry/repository to pull the image from |
-| image.tag | string | `"stable"` | Image tag. Uses `stable` by default; pin to a specific version (e.g. `v9.0.108`) for production |
+| image.repository | string | `"lscr.io/linuxserver/unifi-network-application"` | Docker registry/repository to pull the image from |
+| image.tag | string | `"10.3.55"` | Image tag |
+| mongodb.auth | object | `{"enabled":false,"password":"unifipass","username":"unifi"}` | MongoDB authentication. Disabled by default (internal cluster service only) |
+| mongodb.auth.enabled | bool | `false` | Enable MongoDB authentication |
+| mongodb.auth.password | string | `"unifipass"` | MongoDB password (only used when auth.enabled is true) |
+| mongodb.auth.username | string | `"unifi"` | MongoDB username (only used when auth.enabled is true) |
+| mongodb.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mongodb.image.repository | string | `"mongo"` | MongoDB image repository |
+| mongodb.image.tag | string | `"7.0"` | MongoDB image tag. Must be 6.x or 7.x for UniFi 9+ |
+| mongodb.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the PVC |
+| mongodb.persistence.enabled | bool | `true` | Enable persistent storage for MongoDB data |
+| mongodb.persistence.size | string | `"2Gi"` | Size of the MongoDB PVC |
+| mongodb.persistence.storageClass | string | `""` | Storage class name. Leave empty to use the cluster default |
+| mongodb.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"50m","memory":"256Mi"}}` | MongoDB resource requests and limits |
 | nodeSelector | object | `{}` | Node selector for pod scheduling |
 | persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the PVC |
-| persistence.enabled | bool | `true` | Enable persistent storage for UniFi data |
+| persistence.enabled | bool | `true` | Enable persistent storage for UniFi config/data |
 | persistence.size | string | `"5Gi"` | Size of the PVC |
 | persistence.storageClass | string | `""` | Storage class name. Leave empty to use the cluster default |
-| podSecurityContext | object | `{"fsGroup":999}` | Pod security context |
-| resources | object | `{"limits":{"cpu":"1000m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"512Mi"}}` | Resource requests and limits |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":false,"runAsGroup":999,"runAsNonRoot":true,"runAsUser":999}` | Container security context |
+| podSecurityContext | object | `{}` | Pod security context |
+| resources | object | `{"limits":{"cpu":"1000m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"512Mi"}}` | Resource requests and limits for the UniFi container |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":false,"runAsNonRoot":false}` | Container security context |
 | service.annotations | object | `{}` | Annotations for the service (e.g. for Cilium IP pool selection) |
-| service.ports | list | `[{"name":"http","port":8443,"protocol":"TCP"},{"name":"controller","port":8080,"protocol":"TCP"},{"name":"stun","port":3478,"protocol":"UDP"},{"name":"discovery","port":10001,"protocol":"UDP"},{"name":"speedtest","port":6789,"protocol":"TCP"}]` | Ports exposed by the service. All ports required for full UniFi AP management are included by default. 8443/TCP: HTTPS web UI 8080/TCP: AP device communication (inform) 3478/UDP: STUN (required for AP tunnelling and provisioning) 10001/UDP: L2 device discovery (works only on same broadcast domain) 6789/TCP: UniFi mobile speed test (optional) |
-| service.type | string | `"LoadBalancer"` | Service type. LoadBalancer is required so both the web UI and AP device communication ports are reachable from outside the cluster. |
+| service.ports | list | `[{"name":"http","port":8443,"protocol":"TCP"},{"name":"controller","port":8080,"protocol":"TCP"},{"name":"stun","port":3478,"protocol":"UDP"},{"name":"discovery","port":10001,"protocol":"UDP"},{"name":"speedtest","port":6789,"protocol":"TCP"}]` | Ports exposed by the service. 8443/TCP: HTTPS web UI 8080/TCP: AP device communication (inform) 3478/UDP: STUN (required for AP tunnelling and provisioning) 10001/UDP: L2 device discovery (works only on same broadcast domain) 6789/TCP: UniFi mobile speed test (optional) |
+| service.type | string | `"LoadBalancer"` | Service type. LoadBalancer exposes all ports (UI + AP device communication) |
 | tolerations | list | `[]` | Tolerations for pod scheduling |
 
 ----------------------------------------------

--- a/charts/unifi-network-application/README.md.gotmpl
+++ b/charts/unifi-network-application/README.md.gotmpl
@@ -16,7 +16,10 @@ Helm chart for the UniFi Network Application (WiFi controller) using the `jacoba
 which bundles MongoDB and the controller in a single container.
 
 Includes:
+- **linuxserver/unifi-network-application** container (actively maintained, tracks latest UniFi releases)
+- **Bundled MongoDB 7.0** deployment (no external database required)
 - A single **LoadBalancer** service exposing all required ports: HTTPS web UI (8443/TCP), AP device communication (8080/TCP), STUN (3478/UDP), L2 discovery (10001/UDP), speed test (6789/TCP)
+- Init container that waits for MongoDB before starting the controller
 - Optional **HTTPRoute** for Cilium Gateway API (disabled by default — requires BackendTLSPolicy for HTTPS backend)
 
 ## Adding this helm repository

--- a/charts/unifi-network-application/templates/deployment.yaml
+++ b/charts/unifi-network-application/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-mongodb
+          image: busybox
+          command: ['sh', '-c', 'until nc -z {{ include "unifi-network-application.fullname" . }}-mongodb 27017; do echo "waiting for mongodb..."; sleep 2; done']
       containers:
         - name: unifi-network-application
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -37,20 +41,33 @@ spec:
             - name: discovery
               containerPort: 10001
               protocol: UDP
+            - name: speedtest
+              containerPort: 6789
+              protocol: TCP
           env:
             - name: TZ
               value: {{ .Values.env.TZ | quote }}
-            - name: RUNAS_UID0
-              value: {{ .Values.env.RUNAS_UID0 | quote }}
-            - name: UNIFI_UID
-              value: {{ .Values.env.UNIFI_UID | quote }}
-            - name: UNIFI_GID
-              value: {{ .Values.env.UNIFI_GID | quote }}
-            - name: JVM_MAX_HEAP_SIZE
-              value: {{ .Values.env.JVM_MAX_HEAP_SIZE | quote }}
+            - name: PUID
+              value: {{ .Values.env.PUID | quote }}
+            - name: PGID
+              value: {{ .Values.env.PGID | quote }}
+            - name: MONGO_HOST
+              value: {{ include "unifi-network-application.fullname" . }}-mongodb
+            - name: MONGO_PORT
+              value: "27017"
+            - name: MONGO_DBNAME
+              value: "unifi"
+            {{- if .Values.mongodb.auth.enabled }}
+            - name: MONGO_USER
+              value: {{ .Values.mongodb.auth.username | quote }}
+            - name: MONGO_PASS
+              value: {{ .Values.mongodb.auth.password | quote }}
+            - name: MONGO_AUTHSOURCE
+              value: "admin"
+            {{- end }}
           volumeMounts:
-            - name: data
-              mountPath: /unifi
+            - name: config
+              mountPath: /config
           livenessProbe:
             httpGet:
               scheme: HTTPS
@@ -70,7 +87,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-        - name: data
+        - name: config
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "unifi-network-application.fullname" . }}

--- a/charts/unifi-network-application/templates/mongodb.yaml
+++ b/charts/unifi-network-application/templates/mongodb.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "unifi-network-application.fullname" . }}-mongodb
+  labels:
+    {{- include "unifi-network-application.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "unifi-network-application.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mongodb
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "unifi-network-application.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mongodb
+    spec:
+      containers:
+        - name: mongodb
+          image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
+          imagePullPolicy: {{ .Values.mongodb.image.pullPolicy }}
+          ports:
+            - name: mongodb
+              containerPort: 27017
+              protocol: TCP
+          {{- if .Values.mongodb.auth.enabled }}
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              value: {{ .Values.mongodb.auth.username | quote }}
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              value: {{ .Values.mongodb.auth.password | quote }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+          livenessProbe:
+            exec:
+              command: ["mongosh", "--eval", "db.adminCommand('ping')"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["mongosh", "--eval", "db.adminCommand('ping')"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.mongodb.resources | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.mongodb.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "unifi-network-application.fullname" . }}-mongodb
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "unifi-network-application.fullname" . }}-mongodb
+  labels:
+    {{- include "unifi-network-application.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+spec:
+  type: ClusterIP
+  ports:
+    - name: mongodb
+      port: 27017
+      targetPort: mongodb
+      protocol: TCP
+  selector:
+    {{- include "unifi-network-application.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+{{- if .Values.mongodb.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "unifi-network-application.fullname" . }}-mongodb
+  labels:
+    {{- include "unifi-network-application.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+spec:
+  accessModes:
+    - {{ .Values.mongodb.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.mongodb.persistence.size }}
+  {{- if .Values.mongodb.persistence.storageClass }}
+  storageClassName: {{ .Values.mongodb.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/unifi-network-application/values.yaml
+++ b/charts/unifi-network-application/values.yaml
@@ -1,42 +1,35 @@
 # Default values for unifi-network-application.
 
-# -- Override the full name of all resources (service, deployment, pvc). Recommended: set to a short name like "unifi"
+# -- Override the full name of all resources. Recommended: set to a short name like "unifi"
 fullnameOverride: ""
 
 image:
   # -- Docker registry/repository to pull the image from
-  repository: jacobalberty/unifi
-  # -- Image tag. Uses `stable` by default; pin to a specific version (e.g. `v9.0.108`) for production
-  tag: "stable"
+  repository: lscr.io/linuxserver/unifi-network-application
+  # -- Image tag
+  tag: "10.3.55"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
 env:
-  # -- Timezone for the controller
+  # -- Timezone
   TZ: "Europe/Stockholm"
-  # -- Run as root (set to "true" only if required)
-  RUNAS_UID0: "false"
-  # -- UID the application runs as
-  UNIFI_UID: "999"
-  # -- GID the application runs as
-  UNIFI_GID: "999"
-  # -- JVM maximum heap size. Increase for larger installations
-  JVM_MAX_HEAP_SIZE: "1024M"
+  # -- User ID the application runs as
+  PUID: "1000"
+  # -- Group ID the application runs as
+  PGID: "1000"
 
 # -- Pod security context
-podSecurityContext:
-  fsGroup: 999
+podSecurityContext: {}
 
 # -- Container security context
 securityContext:
-  runAsUser: 999
-  runAsGroup: 999
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: false
-  runAsNonRoot: true
+  runAsNonRoot: false
 
 persistence:
-  # -- Enable persistent storage for UniFi data
+  # -- Enable persistent storage for UniFi config/data
   enabled: true
   # -- Storage class name. Leave empty to use the cluster default
   storageClass: ""
@@ -45,14 +38,46 @@ persistence:
   # -- Size of the PVC
   size: 5Gi
 
+mongodb:
+  image:
+    # -- MongoDB image repository
+    repository: mongo
+    # -- MongoDB image tag. Must be 6.x or 7.x for UniFi 9+
+    tag: "7.0"
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+  # -- MongoDB authentication. Disabled by default (internal cluster service only)
+  auth:
+    # -- Enable MongoDB authentication
+    enabled: false
+    # -- MongoDB username (only used when auth.enabled is true)
+    username: "unifi"
+    # -- MongoDB password (only used when auth.enabled is true)
+    password: "unifipass"
+  persistence:
+    # -- Enable persistent storage for MongoDB data
+    enabled: true
+    # -- Storage class name. Leave empty to use the cluster default
+    storageClass: ""
+    # -- Access mode for the PVC
+    accessMode: ReadWriteOnce
+    # -- Size of the MongoDB PVC
+    size: 2Gi
+  # -- MongoDB resource requests and limits
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 50m
+    limits:
+      memory: 512Mi
+      cpu: 500m
+
 service:
-  # -- Service type. LoadBalancer is required so both the web UI and AP device
-  # communication ports are reachable from outside the cluster.
+  # -- Service type. LoadBalancer exposes all ports (UI + AP device communication)
   type: LoadBalancer
   # -- Annotations for the service (e.g. for Cilium IP pool selection)
   annotations: {}
   # -- Ports exposed by the service.
-  # All ports required for full UniFi AP management are included by default.
   # 8443/TCP: HTTPS web UI
   # 8080/TCP: AP device communication (inform)
   # 3478/UDP: STUN (required for AP tunnelling and provisioning)
@@ -76,16 +101,14 @@ service:
       protocol: TCP
 
 # HTTPRoute via Cilium Gateway API for the web UI.
-# Note: UniFi serves HTTPS only (port 8443). The gateway needs a BackendTLSPolicy
-# to connect to the HTTPS backend. Enable only after extracting the controller CA
-# cert and creating a ConfigMap 'unifi-ca' with key 'ca.crt' in this namespace.
-# Until then, access the UI directly at https://<LoadBalancer-IP>:8443
+# Note: UniFi serves HTTPS only (port 8443). Requires a BackendTLSPolicy.
+# Access the UI directly at https://<LoadBalancer-IP>:8443 until configured.
 httproute:
   # -- Enable HTTPRoute for the web UI
   enabled: false
-  # -- Gateway name to attach the HTTPRoute to
+  # -- Gateway name
   gatewayName: internal-shared
-  # -- Namespace of the gateway
+  # -- Gateway namespace
   gatewayNamespace: kube-system
   # -- Hostname for the HTTPRoute
   hostname: unifi.mgmt.threshold.se
@@ -93,7 +116,7 @@ httproute:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
-# -- Resource requests and limits
+# -- Resource requests and limits for the UniFi container
 resources:
   requests:
     memory: 512Mi


### PR DESCRIPTION
## Summary

- Switch image from `jacobalberty/unifi` (stalled, last update Dec 2025) to `lscr.io/linuxserver/unifi-network-application:10.3.55` (updated Apr 2026)
- Add bundled MongoDB 7.0 Deployment + ClusterIP Service + PVC (required by linuxserver image — no external DB needed)
- Init container waits for MongoDB readiness before starting the controller
- `mongodb.auth.enabled` toggle (default: false — internal cluster service)
- Data directory changed from `/unifi` to `/config`
- Cleaner env vars: `PUID`/`PGID`/`MONGO_*` replacing jacobalberty-specific vars

## Test plan

- [ ] CI passes (excluded from install test — requires real infrastructure)
- [ ] Chart publishes to `janip81.github.io/helm-charts`
- [ ] ArgoCD deploys MongoDB + UniFi pods to `unifi` namespace
- [ ] LoadBalancer gets IP, APs reachable on 8080/TCP + 3478/UDP