### PR TITLE
fix(unifi): 0.2.2 — increase MongoDB probe timeoutSeconds to 10s

### DIFF
--- a/charts/unifi-network-application/Chart.yaml
+++ b/charts/unifi-network-application/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-network-application
 description: Helm chart for the UniFi Network Application (WiFi controller)
 type: application
-version: "0.2.1"
+version: "0.2.2"
 appVersion: "10.3.55"
 home: https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application
 icon: https://prd-www-cdn.ubnt.com/static/favicon-152.png

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -1,6 +1,6 @@
 # unifi-network-application
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
 
 Helm chart for the UniFi Network Application (WiFi controller)
 

--- a/charts/unifi-network-application/templates/mongodb.yaml
+++ b/charts/unifi-network-application/templates/mongodb.yaml
@@ -40,14 +40,16 @@ spec:
           livenessProbe:
             exec:
               command: ["mongosh", "--eval", "db.adminCommand('ping')"]
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 30
+            timeoutSeconds: 10
             failureThreshold: 5
           readinessProbe:
             exec:
               command: ["mongosh", "--eval", "db.adminCommand('ping')"]
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
             periodSeconds: 10
+            timeoutSeconds: 10
             failureThreshold: 3
           resources:
             {{- toYaml .Values.mongodb.resources | nindent 12 }}


### PR DESCRIPTION
## Summary

- MongoDB `mongosh` ping probe was defaulting to `timeoutSeconds: 1` — too tight on first start, causing the pod to be marked not-ready and the UniFi init container to wait indefinitely
- Set `timeoutSeconds: 10` on both liveness and readiness probes
- Bumped `initialDelaySeconds` to 60s (liveness) / 30s (readiness) to give MongoDB more startup headroom

## Test plan

- [ ] MongoDB pod reaches Ready state on fresh install
- [ ] UniFi init container proceeds once MongoDB is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)