### PR TITLE
fix(unifi): 0.2.3 — increase probe initial delays for slow startup

### DIFF
--- a/charts/unifi-network-application/Chart.yaml
+++ b/charts/unifi-network-application/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-network-application
 description: Helm chart for the UniFi Network Application (WiFi controller)
 type: application
-version: "0.2.2"
+version: "0.2.3"
 appVersion: "10.3.55"
 home: https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application
 icon: https://prd-www-cdn.ubnt.com/static/favicon-152.png

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -1,6 +1,6 @@
 # unifi-network-application
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
 
 Helm chart for the UniFi Network Application (WiFi controller)
 

--- a/charts/unifi-network-application/templates/deployment.yaml
+++ b/charts/unifi-network-application/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
               scheme: HTTPS
               path: /status
               port: 8443
-            initialDelaySeconds: 120
+            initialDelaySeconds: 300
             periodSeconds: 30
             failureThreshold: 5
           readinessProbe:
@@ -92,9 +92,9 @@ spec:
               scheme: HTTPS
               path: /status
               port: 8443
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             periodSeconds: 15
-            failureThreshold: 3
+            failureThreshold: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:


### PR DESCRIPTION
## Summary

- UniFi (linuxserver image) takes 5+ minutes on first boot: s6-overlay init, Java startup, MongoDB connection
- Previous `initialDelaySeconds: 120` + 5 failures × 30s meant the liveness probe killed the container at ~4.5 min before it finished starting
- Liveness: `initialDelaySeconds` 120s → 300s
- Readiness: `initialDelaySeconds` 60s → 120s, `failureThreshold` 3 → 10

## Test plan

- [ ] UniFi pod reaches Running/Ready without being killed on first start
- [ ] Liveness probe kicks in only after the controller is fully up

🤖 Generated with [Claude Code](https://claude.com/claude-code)