### PR TITLE
fix(unifi): 0.2.4 — switch MongoDB probes to tcpSocket

### DIFF
--- a/charts/unifi-network-application/Chart.yaml
+++ b/charts/unifi-network-application/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-network-application
 description: Helm chart for the UniFi Network Application (WiFi controller)
 type: application
-version: "0.2.3"
+version: "0.2.4"
 appVersion: "10.3.55"
 home: https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application
 icon: https://prd-www-cdn.ubnt.com/static/favicon-152.png

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -1,6 +1,6 @@
 # unifi-network-application
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
 
 Helm chart for the UniFi Network Application (WiFi controller)
 

--- a/charts/unifi-network-application/templates/mongodb.yaml
+++ b/charts/unifi-network-application/templates/mongodb.yaml
@@ -38,18 +38,18 @@ spec:
             - name: data
               mountPath: /data/db
           livenessProbe:
-            exec:
-              command: ["mongosh", "--eval", "db.adminCommand('ping')"]
-            initialDelaySeconds: 60
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 30
             periodSeconds: 30
-            timeoutSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 5
           readinessProbe:
-            exec:
-              command: ["mongosh", "--eval", "db.adminCommand('ping')"]
-            initialDelaySeconds: 30
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 15
             periodSeconds: 10
-            timeoutSeconds: 10
+            timeoutSeconds: 5
             failureThreshold: 3
           resources:
             {{- toYaml .Values.mongodb.resources | nindent 12 }}


### PR DESCRIPTION
## Summary

- `mongosh` exec probe consistently times out at 10s even though MongoDB is accepting connections — the issue is mongosh startup overhead (DNS resolution / Node.js JVM) inside the container
- Replaced both liveness and readiness probes with `tcpSocket` on port 27017 — instant, no process to spawn, sufficient to confirm MongoDB is listening

## Test plan

- [ ] MongoDB pod reaches 1/1 Ready without probe timeouts
- [ ] UniFi init container proceeds once MongoDB is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)