### PR TITLE
fix(unifi): 0.2.5 — always set MONGO_USER/PASS/AUTHSOURCE

### DIFF
--- a/charts/unifi-network-application/Chart.yaml
+++ b/charts/unifi-network-application/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-network-application
 description: Helm chart for the UniFi Network Application (WiFi controller)
 type: application
-version: "0.2.4"
+version: "0.2.5"
 appVersion: "10.3.55"
 home: https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application
 icon: https://prd-www-cdn.ubnt.com/static/favicon-152.png

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -1,6 +1,6 @@
 # unifi-network-application
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
 
 Helm chart for the UniFi Network Application (WiFi controller)
 

--- a/charts/unifi-network-application/templates/deployment.yaml
+++ b/charts/unifi-network-application/templates/deployment.yaml
@@ -57,14 +57,12 @@ spec:
               value: "27017"
             - name: MONGO_DBNAME
               value: "unifi"
-            {{- if .Values.mongodb.auth.enabled }}
             - name: MONGO_USER
               value: {{ .Values.mongodb.auth.username | quote }}
             - name: MONGO_PASS
               value: {{ .Values.mongodb.auth.password | quote }}
             - name: MONGO_AUTHSOURCE
               value: "admin"
-            {{- end }}
             {{- if .Values.tls.secretName }}
             - name: CERTFILE
               value: /certs/tls.crt


### PR DESCRIPTION
## Summary

UniFi 10.x requires a username in the MongoDB connection string unconditionally — it fails with `No username is provided in the connection string` when `MONGO_USER` is not set.

Previously these env vars were only injected when `mongodb.auth.enabled: true`. Removing that condition so they are always set using the credentials from `mongodb.auth.username/password`.

## Test plan

- [ ] UniFi pod starts without `IllegalStateException: Tomcat failed to start up`
- [ ] Controller connects to MongoDB and reaches Running/Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)