### PR TITLE
fix(unifi): 0.2.6 — add MongoDB init script to create unifi user

### DIFF
--- a/charts/unifi-network-application/Chart.yaml
+++ b/charts/unifi-network-application/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-network-application
 description: Helm chart for the UniFi Network Application (WiFi controller)
 type: application
-version: "0.2.5"
+version: "0.2.6"
 appVersion: "10.3.55"
 home: https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application
 icon: https://prd-www-cdn.ubnt.com/static/favicon-152.png

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -1,6 +1,6 @@
 # unifi-network-application
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
 
 Helm chart for the UniFi Network Application (WiFi controller)
 

--- a/charts/unifi-network-application/templates/mongodb.yaml
+++ b/charts/unifi-network-application/templates/mongodb.yaml
@@ -1,3 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "unifi-network-application.fullname" . }}-mongodb-init
+  labels:
+    {{- include "unifi-network-application.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+data:
+  init-unifi-db.js: |
+    db = db.getSiblingDB({{ .Values.mongodb.auth.dbName | default "unifi" | quote }});
+    db.createUser({
+      user: {{ .Values.mongodb.auth.username | quote }},
+      pwd: {{ .Values.mongodb.auth.password | quote }},
+      roles: [{ role: "dbOwner", db: {{ .Values.mongodb.auth.dbName | default "unifi" | quote }} }]
+    });
+    db = db.getSiblingDB({{ printf "%s_stat" (.Values.mongodb.auth.dbName | default "unifi") | quote }});
+    db.createUser({
+      user: {{ .Values.mongodb.auth.username | quote }},
+      pwd: {{ .Values.mongodb.auth.password | quote }},
+      roles: [{ role: "dbOwner", db: {{ printf "%s_stat" (.Values.mongodb.auth.dbName | default "unifi") | quote }} }]
+    });
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,6 +59,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data/db
+            - name: init-script
+              mountPath: /docker-entrypoint-initdb.d
           livenessProbe:
             tcpSocket:
               port: 27017
@@ -54,6 +78,9 @@ spec:
           resources:
             {{- toYaml .Values.mongodb.resources | nindent 12 }}
       volumes:
+        - name: init-script
+          configMap:
+            name: {{ include "unifi-network-application.fullname" . }}-mongodb-init
         - name: data
           {{- if .Values.mongodb.persistence.enabled }}
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary

UniFi 10.x sends SCRAM authentication to MongoDB on every connection. Even without `--auth` enabled server-side, MongoDB returns `AuthenticationFailed` if the user doesn't exist.

Adds a ConfigMap (`mongodb-init`) with an `initdb` script mounted at `/docker-entrypoint-initdb.d/` that creates the `unifi` user (and `unifi_stat` user) on first MongoDB initialization using the credentials from `mongodb.auth.username/password`.

**Note for existing installs**: if the MongoDB PVC already has data, the init script won't re-run. Create the user manually:
```bash
kubectl exec -n <ns> <mongodb-pod> -- mongosh --eval '
  db = db.getSiblingDB("unifi");
  db.createUser({user:"unifi", pwd:"unifipass", roles:[{role:"dbOwner",db:"unifi"}]});
  db = db.getSiblingDB("unifi_stat");
  db.createUser({user:"unifi", pwd:"unifipass", roles:[{role:"dbOwner",db:"unifi_stat"}]});
'
```

## Test plan

- [ ] Fresh install: MongoDB init script creates unifi user, UniFi connects successfully
- [ ] UniFi pod reaches Running/Ready without AuthenticationFailed errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)