### PR TITLE
feat(unifi): 0.2.8 — support explicit targetPort on service ports

### DIFF
--- a/charts/unifi-network-application/Chart.yaml
+++ b/charts/unifi-network-application/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-network-application
 description: Helm chart for the UniFi Network Application (WiFi controller)
 type: application
-version: "0.2.6"
+version: "0.2.8"
 appVersion: "10.3.55"
 home: https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application
 icon: https://prd-www-cdn.ubnt.com/static/favicon-152.png

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -1,6 +1,6 @@
 # unifi-network-application
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
 
 Helm chart for the UniFi Network Application (WiFi controller)
 

--- a/charts/unifi-network-application/templates/service.yaml
+++ b/charts/unifi-network-application/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
     {{- range .Values.service.ports }}
     - name: {{ .name }}
       port: {{ .port }}
-      targetPort: {{ .name }}
+      targetPort: {{ .targetPort | default .name }}
       protocol: {{ .protocol }}
     {{- end }}
   selector:


### PR DESCRIPTION
## Summary

- Service template now supports an optional `targetPort` field per port entry, falling back to `.name` if not set (backwards compatible)
- This allows adding a port 443 → container port `http` (8443) so the LoadBalancer terminates TLS directly at UniFi using its own cert (Let's Encrypt), bypassing the need for BackendTLSPolicy re-encryption which isn't reliably implemented in Cilium

## Usage

```yaml
service:
  ports:
    - name: https
      port: 443
      targetPort: http   # container port named 'http' = 8443
      protocol: TCP
    # ... existing ports
```

## Test plan

- [ ] Existing deployments unaffected (no `targetPort` set = same behaviour)
- [ ] Port 443 → 8443 mapping works via LB

🤖 Generated with [Claude Code](https://claude.com/claude-code)