### PR TITLE
feat(unifi): 0.2.9 — support appProtocol on service ports

### DIFF
--- a/charts/unifi-network-application/Chart.yaml
+++ b/charts/unifi-network-application/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unifi-network-application
 description: Helm chart for the UniFi Network Application (WiFi controller)
 type: application
-version: "0.2.8"
+version: "0.2.9"
 appVersion: "10.3.55"
 home: https://github.com/janip81/helm-charts/tree/main/charts/unifi-network-application
 icon: https://prd-www-cdn.ubnt.com/static/favicon-152.png

--- a/charts/unifi-network-application/README.md
+++ b/charts/unifi-network-application/README.md
@@ -1,6 +1,6 @@
 # unifi-network-application
 
-![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
+![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.55](https://img.shields.io/badge/AppVersion-10.3.55-informational?style=flat-square)
 
 Helm chart for the UniFi Network Application (WiFi controller)
 

--- a/charts/unifi-network-application/templates/service.yaml
+++ b/charts/unifi-network-application/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
       port: {{ .port }}
       targetPort: {{ .targetPort | default .name }}
       protocol: {{ .protocol }}
+      {{- if .appProtocol }}
+      appProtocol: {{ .appProtocol }}
+      {{- end }}
     {{- end }}
   selector:
     {{- include "unifi-network-application.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## Summary

- Service template now passes through `appProtocol` on each port if set
- Setting `appProtocol: https` on port 8443 tells Cilium Gateway API to connect to the backend over HTTPS (requires `gatewayAPI.appProtocol.enabled: true` in Cilium)
- Backwards compatible — no change if `appProtocol` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)