### PR TITLE
fix(capi-cluster): 0.0.96 — fix OnDelete field path for v1beta2 API

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.95
+version: 0.0.96
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/MachineDeployment.yaml
+++ b/charts/capi-cluster/templates/MachineDeployment.yaml
@@ -19,12 +19,13 @@ spec:
   clusterName: {{ $.Values.cluster.name }}
   replicas: {{ template "worker.replicas" . }}
 {{- if .strategy }}
-  strategy:
-    type: {{ .strategy.type }}
+  rollout:
+    strategy:
+      type: {{ .strategy.type }}
 {{- if and (eq .strategy.type "RollingUpdate") .strategy.rollingUpdate }}
-    rollingUpdate:
-      maxSurge: {{ .strategy.rollingUpdate.maxSurge | default 1 }}
-      maxUnavailable: {{ .strategy.rollingUpdate.maxUnavailable | default 0 }}
+      rollingUpdate:
+        maxSurge: {{ .strategy.rollingUpdate.maxSurge | default 1 }}
+        maxUnavailable: {{ .strategy.rollingUpdate.maxUnavailable | default 0 }}
 {{- end }}
 {{- end }}
   selector:


### PR DESCRIPTION
## Summary

- Fix `strategy` field path for CAPI v1beta2: `spec.strategy` → `spec.rollout.strategy`
- Bump chart version 0.0.95 → 0.0.96

## Root cause

CAPI v1.11 (v1beta2 API) restructured the MachineDeployment spec — `strategy` was moved under a new `rollout` wrapper:

| v1beta1 | v1beta2 |
|---------|---------|
| `spec.strategy.type` | `spec.rollout.strategy.type` |
| `spec.strategy.rollingUpdate` | `spec.rollout.strategy.rollingUpdate` |

The 0.0.95 template rendered `spec.strategy.type` (v1beta1 path), which is not declared in the v1beta2 CRD schema. This caused ArgoCD's structured merge diff to fail with:
```
error building typed value from config resource: .spec.strategy: field not declared in schema
```

## Test plan

- [ ] `helm template` renders `spec.rollout.strategy.type: OnDelete` for pci-node
- [ ] `helm template` with no strategy renders no rollout block (default CAPI behaviour unchanged)
- [ ] ArgoCD diff for `cluster-prod-k8s` no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)