### PR TITLE
feat(capi-cluster): 0.0.97 — add hardwareVersion support to VSphereMachineTemplate

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.96
+version: 0.0.97
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/VsphereMachineTemplate.yaml
+++ b/charts/capi-cluster/templates/VsphereMachineTemplate.yaml
@@ -33,6 +33,9 @@ spec:
       storagePolicyName: "{{ .storagePolicyName }}"
       template: "{{ .isoTemplate }}"
       thumbprint: "{{ $.Values.vsphere.thumbprint }}"
+{{- if .hardwareVersion }}
+      hardwareVersion: "{{ .hardwareVersion }}"
+{{- end }}
 {{- if .pciDevices }}
       pciDevices:
 {{- range .pciDevices }}


### PR DESCRIPTION
## Summary

- Add optional `hardwareVersion` field to `VSphereMachineTemplate` — when set, CAPV upgrades the VM hardware version during FullClone

## Why

PCI passthrough requires vmx-17 or higher. The `ubuntu-2404-kube-v1.34.0` OVA template in vCenter is vmx-15. When CAPV clones it for the PCI node, the clone inherits vmx-15 and vCenter rejects the PCI device assignment with:

> The device or operation specified at index '0' is not supported for the current virtual machine version 'vmx-15'. A minimum version of 'vmx-17' is required.

Setting `hardwareVersion: vmx-17` in the VSphereMachineTemplate instructs CAPV to upgrade the hardware version during the FullClone operation, without needing to re-import the OVA template.

## Usage

```yaml
machineTemplates:
  - name: ubnt2204-8cpu-10g-134-pci
    hardwareVersion: vmx-17   # required for PCI passthrough
    ...
```

## Test plan

- [ ] PCI node VM clones successfully with vmx-17 in vCenter
- [ ] PCI devices attach without error
- [ ] Non-PCI templates without `hardwareVersion` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)