### PR TITLE
feat(n8n): 0.1.3 — configurable liveness/readiness probe settings

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: n8n
 description: n8n workflow automation
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.86.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/n8n
 icon: https://raw.githubusercontent.com/n8n-io/n8n/master/assets/n8n-logo.png

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -171,14 +171,16 @@ spec:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 10
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           livenessProbe:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 30
-            periodSeconds: 20
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
 
           {{- with .Values.resources }}
           resources:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -137,3 +137,13 @@ podSecurityContext:
   fsGroup: 1000
 
 securityContext: {}
+
+livenessProbe:
+  initialDelaySeconds: 120
+  periodSeconds: 20
+  failureThreshold: 3
+
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  failureThreshold: 3


### PR DESCRIPTION
## Summary

- n8n has transient DB connection timeouts at startup (~2 retries × 30s each) before the TypeORM connection pool stabilises
- The hardcoded `initialDelaySeconds:30` + `failureThreshold:3` gave k8s only 90s to decide the container is healthy — not enough
- Both `livenessProbe` and `readinessProbe` settings are now configurable via values

## Changes

- `Chart.yaml`: bumped to `0.1.3`
- `values.yaml`: added `livenessProbe` and `readinessProbe` blocks with sensible defaults (`initialDelaySeconds: 120/30`)
- `deployment.yaml`: probes now use values instead of hardcoded numbers

## Default values

```yaml
livenessProbe:
  initialDelaySeconds: 120  # was 30 — gives n8n time to recover from DB retries
  periodSeconds: 20
  failureThreshold: 3

readinessProbe:
  initialDelaySeconds: 30   # was 10
  periodSeconds: 10
  failureThreshold: 3
```

## Test plan

- [ ] Deploy to prod-k8s with `targetRevision: 0.1.3` in n8n-app.yaml
- [ ] Verify n8n starts and stays Running past the 2-minute mark
- [ ] Verify DB connection established (no crash-loop)