### PR TITLE
capi-cluster 0.0.98: add etcd.extraArgs

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.97
+version: 0.0.98
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/KubeadmControlPlane.yaml
+++ b/charts/capi-cluster/templates/KubeadmControlPlane.yaml
@@ -36,6 +36,10 @@ spec:
           extraArgs:
             - name: listen-metrics-urls
               value: http://0.0.0.0:2381
+            {{- range .Values.etcd.extraArgs }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
       scheduler:
         extraArgs:
           - name: bind-address

--- a/charts/capi-cluster/values.yaml
+++ b/charts/capi-cluster/values.yaml
@@ -205,6 +205,15 @@ addons:
           tag: ""
           pullPolicy: IfNotPresent
 
+# Additional etcd arguments appended to the hardcoded must-haves.
+# Must-haves (always set): listen-metrics-urls=http://0.0.0.0:2381
+etcd:
+  extraArgs: []
+  # - name: auto-compaction-mode
+  #   value: periodic
+  # - name: auto-compaction-retention
+  #   value: "8h"
+
 # Periodic etcd compact + defrag job. Runs as a CronJob on a control-plane node.
 # Discovers etcd members dynamically — no IP configuration needed.
 # image is auto-selected from controlPlaneNodes.k8sVersion (supported: 1.30–1.35).


### PR DESCRIPTION
## Summary
- Adds `etcd.extraArgs` list to values, appended after the hardcoded `listen-metrics-urls` must-have
- Allows per-cluster etcd flags (e.g. `auto-compaction-mode`, `auto-compaction-retention`) without chart changes
- Default is empty list — no change to existing clusters unless opted in

## Test plan
- [ ] Update dev-k8s `cluster-values.yaml` to 0.0.98 with `auto-compaction-retention: "8h"` and verify KCP renders correctly
- [ ] Confirm dev-k8s CP nodes roll with new etcd flag visible in `/etc/kubernetes/manifests/etcd.yaml`
- [ ] Apply to prod-k8s after dev-k8s validates