### PR TITLE
capi-cluster 0.0.99: add cluster.paused support

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.98
+version: 0.0.99
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/Cluster.yaml
+++ b/charts/capi-cluster/templates/Cluster.yaml
@@ -15,6 +15,7 @@ metadata:
     etcd-defrag: enabled
     {{- end }}
 spec:
+  paused: {{ default false .Values.cluster.paused }}
   clusterNetwork:
     pods:
       cidrBlocks:

--- a/charts/capi-cluster/values.yaml
+++ b/charts/capi-cluster/values.yaml
@@ -6,6 +6,10 @@ cluster:
   # bgpPolicyVlan node label is used in Cilium CNI BGP, if not used leave empty and it will not be set.
   bgpPolicyVlan: "vlan201"
   skipKubeProxy: true
+  # paused stops CAPI from reconciling the cluster. Set to true, then power off
+  # the VMs in vCenter to free resources. To bring back: power on VMs first,
+  # then set paused: false so CAPI resumes and the cluster recovers.
+  paused: false
 
 # Read about different levels
 # https://kubernetes.io/docs/concepts/security/pod-security-standards/


### PR DESCRIPTION
## Summary
- Adds `cluster.paused: false` to values — maps directly to `Cluster.spec.paused`
- When `true`, CAPI stops reconciling the cluster (won't try to remediate powered-off VMs)
- Default is `false` — no change to existing clusters

## Usage
To suspend a cluster and free ESXi resources:
1. Set `cluster.paused: true` in cluster-values.yaml and push
2. Wait for ArgoCD to sync
3. Power off the VMs in vCenter

To bring it back:
1. Power on VMs in vCenter first
2. Set `cluster.paused: false` and push
3. CAPI resumes reconciliation, cluster recovers on its own

## Test plan
- [ ] Update dev-k8s to 0.0.99 with `cluster.paused: true`, verify `Cluster.spec.paused=true` in prod-mgmt
- [ ] Verify CAPI stops reconciling (MachineHealthChecks suspended)
- [ ] Power off dev-k8s VMs in vCenter, verify no new VMs created
- [ ] Power on, set `paused: false`, verify cluster recovers