### PR TITLE
ghost: add optional SMTP mail configuration (0.1.1)

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ghost
 description: Ghost blogging platform with external MySQL/MariaDB
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "6.32.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/ghost
 icon: https://ghost.org/favicon.ico
@@ -24,4 +24,4 @@ annotations:
       url: https://github.com/janip81/helm-charts/tree/main/charts/ghost/
   artifacthub.io/changes: |
     - kind: added
-      description: Initial release
+      description: Optional SMTP mail configuration

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -1,6 +1,6 @@
 # ghost
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.32.0](https://img.shields.io/badge/AppVersion-6.32.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.32.0](https://img.shields.io/badge/AppVersion-6.32.0-informational?style=flat-square)
 
 Ghost blogging platform with external MySQL/MariaDB
 
@@ -110,6 +110,15 @@ gatewayApi:
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.periodSeconds | int | `30` |  |
 | livenessProbe.timeoutSeconds | int | `5` |  |
+| mail.enabled | bool | `false` |  |
+| mail.from | string | `""` |  |
+| mail.host | string | `""` |  |
+| mail.passwordSecret.key | string | `""` |  |
+| mail.passwordSecret.name | string | `""` |  |
+| mail.port | int | `587` |  |
+| mail.secure | bool | `false` |  |
+| mail.transport | string | `"SMTP"` |  |
+| mail.user | string | `""` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -62,6 +62,25 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.database.passwordSecret.name }}
                   key: {{ .Values.database.passwordSecret.key }}
+            {{- if .Values.mail.enabled }}
+            - name: mail__transport
+              value: {{ .Values.mail.transport | quote }}
+            - name: mail__from
+              value: {{ .Values.mail.from | quote }}
+            - name: mail__options__host
+              value: {{ .Values.mail.host | quote }}
+            - name: mail__options__port
+              value: {{ .Values.mail.port | quote }}
+            - name: mail__options__secure
+              value: {{ .Values.mail.secure | quote }}
+            - name: mail__options__auth__user
+              value: {{ .Values.mail.user | quote }}
+            - name: mail__options__auth__pass
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mail.passwordSecret.name }}
+                  key: {{ .Values.mail.passwordSecret.key }}
+            {{- end }}
           startupProbe:
             httpGet:
               path: /

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -40,6 +40,18 @@ gatewayApi:
     - name: internal-shared
       namespace: kube-system
 
+mail:
+  enabled: false
+  from: ""
+  transport: SMTP
+  host: ""
+  port: 587
+  secure: false
+  user: ""
+  passwordSecret:
+    name: ""
+    key: ""
+
 resources: {}
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
## Summary
- Adds optional SMTP mail configuration to the Ghost chart
- Controlled by `mail.enabled` (default: false, no breaking change)
- Passes Ghost mail env vars (`mail__transport`, `mail__from`, `mail__options__*`)
- Password sourced from a Kubernetes secret reference

## Test plan
- [ ] Deploy with `mail.enabled: true` and valid SMTP credentials
- [ ] Verify Ghost admin magic link email is delivered