### PR TITLE
feat: add claude-memory chart v0.1.0

### DIFF
--- a/charts/claude-memory/Chart.yaml
+++ b/charts/claude-memory/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: claude-memory
+description: MCP memory server — mem0 + pgvector + Ollama embeddings
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/janip81/helm-charts/tree/main/charts/claude-memory
+keywords:
+  - mcp
+  - memory
+  - mem0
+  - pgvector
+  - ollama
+maintainers:
+  - name: janip81
+    email: jani@techmonkeys.se
+    url: https://github.com/janip81
+sources:
+  - https://github.com/janip81/helm-charts/tree/main/charts/claude-memory/
+  - https://github.com/janip81/claude-memory
+annotations:
+  artifacthub.io/links: |
+    - name: Chart source
+      url: https://github.com/janip81/helm-charts/tree/main/charts/claude-memory/

--- a/charts/claude-memory/README.md
+++ b/charts/claude-memory/README.md
@@ -1,0 +1,126 @@
+# claude-memory
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+
+MCP memory server — mem0 + pgvector + Ollama embeddings
+
+**Homepage:** <https://github.com/janip81/helm-charts/tree/main/charts/claude-memory>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| janip81 | <jani@techmonkeys.se> | <https://github.com/janip81> |
+
+## Source Code
+
+* <https://github.com/janip81/helm-charts/tree/main/charts/claude-memory/>
+* <https://github.com/janip81/claude-memory>
+
+# Overview
+
+Helm chart for deploying [claude-memory](https://github.com/janip81/claude-memory) — a self-hosted MCP memory server built on [mem0](https://github.com/mem0ai/mem0), pgvector (via CNPG), and Ollama embeddings.
+
+Gives Claude Code persistent semantic memory across sessions. Facts are stored directly in pgvector and retrieved via semantic search — no LLM API calls required.
+
+## Adding this helm repository
+
+```bash
+helm repo add janip81 https://janip81.github.io/helm-charts/
+helm search repo claude-memory
+```
+
+## Prerequisites
+
+- **Ollama** running and reachable with `nomic-embed-text` pulled:
+  ```bash
+  ollama pull nomic-embed-text
+  ```
+- **CNPG operator** installed in the cluster (for the managed PostgreSQL cluster)
+- A Kubernetes Secret with `BEARER_TOKEN` key (pre-created or via AVP):
+  ```bash
+  kubectl -n claude-memory create secret generic claude-memory-auth \
+    --from-literal=BEARER_TOKEN='your-token'
+  ```
+
+## TL;DR
+
+```bash
+helm repo add janip81 https://janip81.github.io/helm-charts/
+helm install claude-memory janip81/claude-memory \
+  --namespace claude-memory \
+  --create-namespace \
+  --set gatewayApi.host=mem0-mcp.your-domain.com \
+  --set ollama.baseUrl=http://your-ollama-host:11434 \
+  --set cnpg.storage.storageClass=your-storage-class
+```
+
+## Connecting Claude Code
+
+After deployment:
+
+```bash
+claude mcp add --transport http --scope user mem0-mcp https://mem0-mcp.your-domain.com/mcp
+```
+
+Enter the bearer token when prompted.
+
+## Gateway API (HTTPRoute)
+
+```yaml
+gatewayApi:
+  enabled: true
+  host: mem0-mcp.your-domain.com
+  parentRefs:
+    - name: internal-shared
+      namespace: kube-system
+```
+
+## CNPG Backup (Barman S3)
+
+```yaml
+cnpg:
+  backup:
+    enabled: true
+    destinationPath: s3://my-bucket/claude-memory
+    endpointURL: https://s3.example.com
+    s3CredentialsSecret: cnpg-barman-s3-creds
+    retentionPolicy: "30d"
+```
+
+The `s3CredentialsSecret` must contain keys: `access-key-id`, `secret-access-key`, `region`.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| auth.secretName | string | `"claude-memory-auth"` | Name of the Secret containing BEARER_TOKEN (pre-created or rendered by AVP) |
+| cnpg.backup.destinationPath | string | `"s3://my-bucket/claude-memory"` | S3 destination path |
+| cnpg.backup.enabled | bool | `false` | Enable Barman S3 backup |
+| cnpg.backup.endpointURL | string | `"https://s3.example.com"` | S3 endpoint URL |
+| cnpg.backup.retentionPolicy | string | `"30d"` | Backup retention policy |
+| cnpg.backup.s3CredentialsSecret | string | `"cnpg-barman-s3-creds"` | Name of the Secret containing S3 credentials (keys: access-key-id, secret-access-key, region) |
+| cnpg.enabled | bool | `true` | Enable CNPG PostgreSQL cluster |
+| cnpg.instances | int | `1` | Number of CNPG instances |
+| cnpg.storage.size | string | `"5Gi"` | Storage size for the CNPG cluster |
+| cnpg.storage.storageClass | string | `""` | Storage class for the CNPG cluster |
+| gatewayApi.enabled | bool | `true` | Enable Gateway API HTTPRoute |
+| gatewayApi.host | string | `"mem0-mcp.prod.example.com"` | Hostname for the HTTPRoute |
+| gatewayApi.parentRefs | list | `[{"name":"internal-shared","namespace":"kube-system"}]` | Gateway parentRefs |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"ghcr.io/janip81/claude-memory"` | Image repository |
+| image.tag | string | `"latest"` | Image tag |
+| mem0.userId | string | `"default"` | User ID namespace for stored memories |
+| ollama.baseUrl | string | `"http://ollama:11434"` | Ollama server URL |
+| ollama.embedModel | string | `"nomic-embed-text"` | Embedding model (must be pulled in Ollama) |
+| ollama.model | string | `"qwen2.5:7b"` | Chat model for LLM operations |
+| replicaCount | int | `1` | Number of replicas |
+| resources.limits.cpu | string | `"500m"` | CPU limit |
+| resources.limits.memory | string | `"512Mi"` | Memory limit |
+| resources.requests.cpu | string | `"100m"` | CPU request |
+| resources.requests.memory | string | `"256Mi"` | Memory request |
+| service.port | int | `8080` | Service port |
+| service.type | string | `"ClusterIP"` | Service type |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/claude-memory/README.md.gotmpl
+++ b/charts/claude-memory/README.md.gotmpl
@@ -1,0 +1,91 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+# Overview
+
+Helm chart for deploying [claude-memory](https://github.com/janip81/claude-memory) — a self-hosted MCP memory server built on [mem0](https://github.com/mem0ai/mem0), pgvector (via CNPG), and Ollama embeddings.
+
+Gives Claude Code persistent semantic memory across sessions. Facts are stored directly in pgvector and retrieved via semantic search — no LLM API calls required.
+
+## Adding this helm repository
+
+```bash
+helm repo add janip81 https://janip81.github.io/helm-charts/
+helm search repo claude-memory
+```
+
+## Prerequisites
+
+- **Ollama** running and reachable with `nomic-embed-text` pulled:
+  ```bash
+  ollama pull nomic-embed-text
+  ```
+- **CNPG operator** installed in the cluster (for the managed PostgreSQL cluster)
+- A Kubernetes Secret with `BEARER_TOKEN` key (pre-created or via AVP):
+  ```bash
+  kubectl -n claude-memory create secret generic claude-memory-auth \
+    --from-literal=BEARER_TOKEN='your-token'
+  ```
+
+## TL;DR
+
+```bash
+helm repo add janip81 https://janip81.github.io/helm-charts/
+helm install claude-memory janip81/claude-memory \
+  --namespace claude-memory \
+  --create-namespace \
+  --set gatewayApi.host=mem0-mcp.your-domain.com \
+  --set ollama.baseUrl=http://your-ollama-host:11434 \
+  --set cnpg.storage.storageClass=your-storage-class
+```
+
+## Connecting Claude Code
+
+After deployment:
+
+```bash
+claude mcp add --transport http --scope user mem0-mcp https://mem0-mcp.your-domain.com/mcp
+```
+
+Enter the bearer token when prompted.
+
+## Gateway API (HTTPRoute)
+
+```yaml
+gatewayApi:
+  enabled: true
+  host: mem0-mcp.your-domain.com
+  parentRefs:
+    - name: internal-shared
+      namespace: kube-system
+```
+
+## CNPG Backup (Barman S3)
+
+```yaml
+cnpg:
+  backup:
+    enabled: true
+    destinationPath: s3://my-bucket/claude-memory
+    endpointURL: https://s3.example.com
+    s3CredentialsSecret: cnpg-barman-s3-creds
+    retentionPolicy: "30d"
+```
+
+The `s3CredentialsSecret` must contain keys: `access-key-id`, `secret-access-key`, `region`.
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/claude-memory/templates/_helpers.tpl
+++ b/charts/claude-memory/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{- define "claude-memory.name" -}}
+{{- .Chart.Name }}
+{{- end }}
+
+{{- define "claude-memory.fullname" -}}
+{{- .Release.Name }}-{{ .Chart.Name }}
+{{- end }}
+
+{{- define "claude-memory.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ include "claude-memory.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "claude-memory.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "claude-memory.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/claude-memory/templates/cnpg-cluster.yaml
+++ b/charts/claude-memory/templates/cnpg-cluster.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.cnpg.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "claude-memory.fullname" . }}-pg
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "claude-memory.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.cnpg.instances }}
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+
+  storage:
+    size: {{ .Values.cnpg.storage.size }}
+    storageClass: {{ .Values.cnpg.storage.storageClass }}
+
+  postgresql:
+    shared_preload_libraries:
+      - vector
+
+  bootstrap:
+    initdb:
+      database: mem0
+      owner: mem0
+      postInitSQL:
+        - "CREATE EXTENSION IF NOT EXISTS vector;"
+
+  {{- if .Values.cnpg.backup.enabled }}
+  backup:
+    barmanObjectStore:
+      destinationPath: {{ .Values.cnpg.backup.destinationPath | quote }}
+      endpointURL: {{ .Values.cnpg.backup.endpointURL | quote }}
+      s3Credentials:
+        accessKeyId:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: access-key-id
+        secretAccessKey:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: secret-access-key
+        region:
+          name: {{ .Values.cnpg.backup.s3CredentialsSecret }}
+          key: region
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+    retentionPolicy: {{ .Values.cnpg.backup.retentionPolicy | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/claude-memory/templates/deployment.yaml
+++ b/charts/claude-memory/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "claude-memory.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "claude-memory.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "claude-memory.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "claude-memory.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: claude-memory
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: APP_PORT
+              value: "8080"
+            - name: BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.secretName }}
+                  key: BEARER_TOKEN
+            - name: DATABASE_URL
+              value: "postgresql://mem0:$(DB_PASSWORD)@{{ include "claude-memory.fullname" . }}-pg-rw:5432/mem0"
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "claude-memory.fullname" . }}-pg-app
+                  key: password
+            - name: OLLAMA_BASE_URL
+              value: {{ .Values.ollama.baseUrl | quote }}
+            - name: OLLAMA_MODEL
+              value: {{ .Values.ollama.model | quote }}
+            - name: OLLAMA_EMBED_MODEL
+              value: {{ .Values.ollama.embedModel | quote }}
+            - name: MEM0_USER_ID
+              value: {{ .Values.mem0.userId | quote }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/claude-memory/templates/httproute.yaml
+++ b/charts/claude-memory/templates/httproute.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.gatewayApi.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "claude-memory.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "claude-memory.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  hostnames:
+    - {{ .Values.gatewayApi.host | quote }}
+  parentRefs:
+  {{- range .Values.gatewayApi.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      group: gateway.networking.k8s.io
+      kind: Gateway
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "claude-memory.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1
+{{- end }}

--- a/charts/claude-memory/templates/service.yaml
+++ b/charts/claude-memory/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "claude-memory.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "claude-memory.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "claude-memory.selectorLabels" . | nindent 4 }}

--- a/charts/claude-memory/values.yaml
+++ b/charts/claude-memory/values.yaml
@@ -1,0 +1,76 @@
+# -- Number of replicas
+replicaCount: 1
+
+image:
+  # -- Image repository
+  repository: ghcr.io/janip81/claude-memory
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Image tag
+  tag: "latest"
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 8080
+
+gatewayApi:
+  # -- Enable Gateway API HTTPRoute
+  enabled: true
+  # -- Hostname for the HTTPRoute
+  host: mem0-mcp.prod.example.com
+  # -- Gateway parentRefs
+  parentRefs:
+    - name: internal-shared
+      namespace: kube-system
+
+resources:
+  requests:
+    # -- CPU request
+    cpu: 100m
+    # -- Memory request
+    memory: 256Mi
+  limits:
+    # -- CPU limit
+    cpu: 500m
+    # -- Memory limit
+    memory: 512Mi
+
+auth:
+  # -- Name of the Secret containing BEARER_TOKEN (pre-created or rendered by AVP)
+  secretName: claude-memory-auth
+
+ollama:
+  # -- Ollama server URL
+  baseUrl: "http://ollama:11434"
+  # -- Chat model for LLM operations
+  model: "qwen2.5:7b"
+  # -- Embedding model (must be pulled in Ollama)
+  embedModel: "nomic-embed-text"
+
+mem0:
+  # -- User ID namespace for stored memories
+  userId: "default"
+
+cnpg:
+  # -- Enable CNPG PostgreSQL cluster
+  enabled: true
+  # -- Number of CNPG instances
+  instances: 1
+  storage:
+    # -- Storage size for the CNPG cluster
+    size: 5Gi
+    # -- Storage class for the CNPG cluster
+    storageClass: ""
+  backup:
+    # -- Enable Barman S3 backup
+    enabled: false
+    # -- S3 destination path
+    destinationPath: "s3://my-bucket/claude-memory"
+    # -- S3 endpoint URL
+    endpointURL: "https://s3.example.com"
+    # -- Name of the Secret containing S3 credentials (keys: access-key-id, secret-access-key, region)
+    s3CredentialsSecret: cnpg-barman-s3-creds
+    # -- Backup retention policy
+    retentionPolicy: "30d"


### PR DESCRIPTION
## Summary

- New chart `claude-memory` v0.1.0 — self-hosted MCP memory server
- mem0 + pgvector (CNPG) + Ollama embeddings (nomic-embed-text)
- No external API keys required — fully local
- Resources: Deployment, Service, HTTPRoute (Gateway API), CNPG Cluster
- Optional Barman S3 backup
- helm-docs generated README

## Test plan

- [ ] `helm template` renders all 4 resources cleanly
- [ ] Chart published to GitHub Pages after merge
- [ ] ArgoCD deploys successfully in prod-k8s