### PR TITLE
fix: claude-memory 0.1.1 — add imagePullSecrets support

### DIFF
--- a/charts/claude-memory/Chart.yaml
+++ b/charts/claude-memory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: claude-memory
 description: MCP memory server — mem0 + pgvector + Ollama embeddings
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/claude-memory
 keywords:

--- a/charts/claude-memory/README.md
+++ b/charts/claude-memory/README.md
@@ -1,6 +1,6 @@
 # claude-memory
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 MCP memory server — mem0 + pgvector + Ollama embeddings
 
@@ -110,6 +110,7 @@ The `s3CredentialsSecret` must contain keys: `access-key-id`, `secret-access-key
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"ghcr.io/janip81/claude-memory"` | Image repository |
 | image.tag | string | `"latest"` | Image tag |
+| imagePullSecrets | list | `[]` | Image pull secrets for private registries (e.g. ghcr.io) |
 | mem0.userId | string | `"default"` | User ID namespace for stored memories |
 | ollama.baseUrl | string | `"http://ollama:11434"` | Ollama server URL |
 | ollama.embedModel | string | `"nomic-embed-text"` | Embedding model (must be pulled in Ollama) |

--- a/charts/claude-memory/templates/deployment.yaml
+++ b/charts/claude-memory/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: claude-memory
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/claude-memory/values.yaml
+++ b/charts/claude-memory/values.yaml
@@ -1,6 +1,9 @@
 # -- Number of replicas
 replicaCount: 1
 
+# -- Image pull secrets for private registries (e.g. ghcr.io)
+imagePullSecrets: []
+
 image:
   # -- Image repository
   repository: ghcr.io/janip81/claude-memory


### PR DESCRIPTION
## Summary

- Add `imagePullSecrets` to Deployment (needed for private ghcr.io image)
- Bump chart version 0.1.0 → 0.1.1

## Test plan

- [ ] Chart published to GitHub Pages after merge
- [ ] ArgoCD deploys pod successfully with ghcr-creds pull secret