### PR TITLE
fix(claude-memory): standard fullname template, v0.1.2

### DIFF
--- a/charts/claude-memory/Chart.yaml
+++ b/charts/claude-memory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: claude-memory
 description: MCP memory server — mem0 + pgvector + Ollama embeddings
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/claude-memory
 keywords:

--- a/charts/claude-memory/README.md
+++ b/charts/claude-memory/README.md
@@ -1,6 +1,6 @@
 # claude-memory
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 MCP memory server — mem0 + pgvector + Ollama embeddings
 

--- a/charts/claude-memory/templates/_helpers.tpl
+++ b/charts/claude-memory/templates/_helpers.tpl
@@ -3,7 +3,16 @@
 {{- end }}
 
 {{- define "claude-memory.fullname" -}}
-{{- .Release.Name }}-{{ .Chart.Name }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- define "claude-memory.labels" -}}


### PR DESCRIPTION
## Summary
- Fix `_helpers.tpl` to use the standard Helm fullname template (same as ghost chart)
- When release name already contains the chart name, only the release name is used — avoids `claude-memory-claude-memory-*` doubling
- Adds `fullnameOverride` / `nameOverride` support for flexibility
- Bump to 0.1.2

## Effect
With `releaseName: claude-memory` and `chartName: claude-memory`:
- Before: `claude-memory-claude-memory-<suffix>`
- After: `claude-memory-<suffix>`

## Test plan
- [ ] Apply 0.1.2 to cluster, verify resources named `claude-memory-*` not `claude-memory-claude-memory-*`
- [ ] Verify CNPG cluster starts as `claude-memory-pg`
- [ ] Verify service/deployment naming correct