### PR TITLE
fix(claude-memory): 0.1.5 — fix MCP service selector routing to UI pods

### DIFF
--- a/charts/claude-memory/Chart.yaml
+++ b/charts/claude-memory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: claude-memory
 description: MCP memory server — mem0 + pgvector + Ollama embeddings
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.1.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/claude-memory
 keywords:

--- a/charts/claude-memory/templates/deployment.yaml
+++ b/charts/claude-memory/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         {{- include "claude-memory.labels" . | nindent 8 }}
+        app.kubernetes.io/component: mcp
     spec:
       securityContext:
         runAsNonRoot: true

--- a/charts/claude-memory/templates/service.yaml
+++ b/charts/claude-memory/templates/service.yaml
@@ -14,3 +14,4 @@ spec:
       name: http
   selector:
     {{- include "claude-memory.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp


### PR DESCRIPTION
## Summary
- MCP service selector used base labels only (`name + instance`), matching both MCP and UI pods
- Added `app.kubernetes.io/component: mcp` to MCP pod template labels and service selector
- Service now routes exclusively to MCP pods

## Root cause
When the UI deployment was added (0.1.3), the UI pods got `component: ui` but MCP pods had no `component` label. The MCP service had no way to distinguish between pod types, causing round-robin between MCP and UI.