### PR TITLE
fix(claude-memory): 0.1.6 — fix DB_PASSWORD env var order

### DIFF
--- a/charts/claude-memory/Chart.yaml
+++ b/charts/claude-memory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: claude-memory
 description: MCP memory server — mem0 + pgvector + Ollama embeddings
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.1.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/claude-memory
 keywords:

--- a/charts/claude-memory/templates/deployment.yaml
+++ b/charts/claude-memory/templates/deployment.yaml
@@ -39,13 +39,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.auth.secretName }}
                   key: BEARER_TOKEN
-            - name: DATABASE_URL
-              value: "postgresql://mem0:$(DB_PASSWORD)@{{ include "claude-memory.fullname" . }}-pg-rw:5432/mem0"
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "claude-memory.fullname" . }}-pg-app
                   key: password
+            - name: DATABASE_URL
+              value: "postgresql://mem0:$(DB_PASSWORD)@{{ include "claude-memory.fullname" . }}-pg-rw:5432/mem0"
             - name: OLLAMA_BASE_URL
               value: {{ .Values.ollama.baseUrl | quote }}
             - name: OLLAMA_MODEL


### PR DESCRIPTION
## Summary
- Moves `DB_PASSWORD` before `DATABASE_URL` in the MCP deployment env list
- Kubernetes env var substitution (`$(VAR)`) requires the source var to appear first
- Previous order caused `DATABASE_URL` to contain the literal string `$(DB_PASSWORD)` → psycopg2 auth failure