### PR TITLE
feat(claude-memory): split MCP and UI into separate images (0.1.7)

### DIFF
--- a/charts/claude-memory/Chart.yaml
+++ b/charts/claude-memory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: claude-memory
 description: MCP memory server — mem0 + pgvector + Ollama embeddings
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "0.1.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/claude-memory
 keywords:

--- a/charts/claude-memory/templates/deployment-ui.yaml
+++ b/charts/claude-memory/templates/deployment-ui.yaml
@@ -28,9 +28,8 @@ spec:
       {{- end }}
       containers:
         - name: claude-memory-ui
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["python", "src/ui/app.py"]
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.ui.port }}

--- a/charts/claude-memory/values.yaml
+++ b/charts/claude-memory/values.yaml
@@ -19,12 +19,19 @@ service:
   port: 8080
 
 ui:
-  # -- Enable the memory browser UI (separate pod, same image)
+  # -- Enable the memory browser UI (separate pod, separate image)
   enabled: true
   # -- Port the UI listens on inside the container
   port: 8081
   # -- Hostname for the UI HTTPRoute (leave empty to share MCP hostname with path routing)
   host: ""
+  image:
+    # -- UI image repository (separate from MCP image)
+    repository: ghcr.io/janip81/claude-memory-ui
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+    # -- Image tag
+    tag: "latest"
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
## Summary

- Adds `ui.image` block to `values.yaml` — UI pod now has its own image (`ghcr.io/janip81/claude-memory-ui`)
- `deployment-ui.yaml` references `ui.image.*` instead of `image.*`, and drops the `command` override (UI image has `CMD ["python", "src/ui/app.py"]` baked in)
- MCP image (`image.*`) unchanged — still `ghcr.io/janip81/claude-memory`
- Chart version: 0.1.6 → 0.1.7

## Why

MCP server requires mem0ai, psycopg2, ollama (~500MB). UI only needs fastapi, jinja2, httpx (~64MB). Sharing one image meant the UI pod loaded the full ML stack at import time and got OOM-killed. Separate images fix the OOM and allow independent build pipelines as the UI is rewritten in React.