### PR TITLE
feat(claude-memory): infer + agent_id support (0.1.8)

### DIFF
--- a/charts/claude-memory/Chart.yaml
+++ b/charts/claude-memory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: claude-memory
 description: MCP memory server — mem0 + pgvector + Ollama embeddings
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: "0.1.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/claude-memory
 keywords:

--- a/charts/claude-memory/templates/deployment.yaml
+++ b/charts/claude-memory/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
               value: {{ .Values.ollama.embedModel | quote }}
             - name: MEM0_USER_ID
               value: {{ .Values.mem0.userId | quote }}
+            - name: MEM0_AGENT_ID
+              value: {{ .Values.mem0.agentId | quote }}
+            - name: MEM0_INFER
+              value: {{ .Values.mem0.infer | quote }}
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/claude-memory/values.yaml
+++ b/charts/claude-memory/values.yaml
@@ -77,6 +77,10 @@ ollama:
 mem0:
   # -- User ID namespace for stored memories
   userId: "default"
+  # -- Default agent ID tag (overridden per client via X-Agent-ID header)
+  agentId: "default"
+  # -- Enable LLM extraction and deduplication on add_memory calls
+  infer: "true"
 
 cnpg:
   # -- Enable CNPG PostgreSQL cluster


### PR DESCRIPTION
## Summary

- Adds `mem0.infer` (default `true`) and `mem0.agentId` (default `default`) to values.yaml
- Passes `MEM0_INFER` and `MEM0_AGENT_ID` env vars to the MCP deployment
- Clients set `X-Agent-ID` header in their MCP config to tag which agent added a memory (claude-starbase, claude-desktop, cursor, etc.)
- Server reads header and passes it through to mem0 on every add/search call
- Chart 0.1.7 → 0.1.8