### PR TITLE
feat(remnant): 0.2.3 — settings ConfigMap, DB-backed tag rules, LLM tagging phase, job history

### DIFF
--- a/charts/claude-memory/README.md
+++ b/charts/claude-memory/README.md
@@ -1,6 +1,6 @@
 # claude-memory
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 MCP memory server — mem0 + pgvector + Ollama embeddings
 
@@ -104,6 +104,14 @@ The `s3CredentialsSecret` must contain keys: `access-key-id`, `secret-access-key
 | cnpg.instances | int | `1` | Number of CNPG instances |
 | cnpg.storage.size | string | `"5Gi"` | Storage size for the CNPG cluster |
 | cnpg.storage.storageClass | string | `""` | Storage class for the CNPG cluster |
+| dedup.enabled | bool | `true` | Enable the deduplication CronJob |
+| dedup.resources.limits.cpu | string | `"500m"` |  |
+| dedup.resources.limits.memory | string | `"256Mi"` |  |
+| dedup.resources.requests.cpu | string | `"100m"` |  |
+| dedup.resources.requests.memory | string | `"128Mi"` |  |
+| dedup.schedule | string | `"30 3 * * *"` | Cron schedule (default: 03:30 daily, after CNPG backup window) |
+| dedup.semanticThreshold | string | `"0.92"` | Cosine similarity threshold for semantic near-dedup (0–1, higher = stricter) |
+| dedup.suspend | bool | `false` | Suspend the CronJob without deleting it |
 | gatewayApi.enabled | bool | `true` | Enable Gateway API HTTPRoute |
 | gatewayApi.host | string | `"mem0-mcp.prod.example.com"` | Hostname for the MCP HTTPRoute |
 | gatewayApi.parentRefs | list | `[{"name":"internal-shared","namespace":"kube-system"}]` | Gateway parentRefs |
@@ -111,6 +119,8 @@ The `s3CredentialsSecret` must contain keys: `access-key-id`, `secret-access-key
 | image.repository | string | `"ghcr.io/janip81/claude-memory"` | Image repository |
 | image.tag | string | `"latest"` | Image tag |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries (e.g. ghcr.io) |
+| mem0.agentId | string | `"default"` | Default agent ID tag (overridden per client via X-Agent-ID header) |
+| mem0.infer | string | `"true"` | Enable LLM extraction and deduplication on add_memory calls |
 | mem0.userId | string | `"default"` | User ID namespace for stored memories |
 | ollama.baseUrl | string | `"http://ollama:11434"` | Ollama server URL |
 | ollama.embedModel | string | `"nomic-embed-text"` | Embedding model (must be pulled in Ollama) |
@@ -122,8 +132,11 @@ The `s3CredentialsSecret` must contain keys: `access-key-id`, `secret-access-key
 | resources.requests.memory | string | `"256Mi"` | Memory request |
 | service.port | int | `8080` | Service port |
 | service.type | string | `"ClusterIP"` | Service type |
-| ui.enabled | bool | `true` | Enable the memory browser UI (separate pod, same image) |
+| ui.enabled | bool | `true` | Enable the memory browser UI (separate pod, separate image) |
 | ui.host | string | `""` | Hostname for the UI HTTPRoute (leave empty to share MCP hostname with path routing) |
+| ui.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| ui.image.repository | string | `"ghcr.io/janip81/claude-memory-ui"` | UI image repository (separate from MCP image) |
+| ui.image.tag | string | `"latest"` | Image tag |
 | ui.port | int | `8081` | Port the UI listens on inside the container |
 | ui.resources.limits.cpu | string | `"200m"` |  |
 | ui.resources.limits.memory | string | `"128Mi"` |  |

--- a/charts/remnant/Chart.yaml
+++ b/charts/remnant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: remnant
 description: Remnant — a shared local memory layer for stateless AI agents
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "0.2.0"
 icon: https://raw.githubusercontent.com/janip81/helm-charts/main/charts/remnant/icon.png
 home: https://github.com/janip81/helm-charts/tree/main/charts/remnant

--- a/charts/remnant/README.md
+++ b/charts/remnant/README.md
@@ -1,10 +1,10 @@
-# claude-memory
+# remnant
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
-MCP memory server — mem0 + pgvector + Ollama embeddings
+Remnant — a shared local memory layer for stateless AI agents
 
-**Homepage:** <https://github.com/janip81/helm-charts/tree/main/charts/claude-memory>
+**Homepage:** <https://github.com/janip81/helm-charts/tree/main/charts/remnant>
 
 ## Maintainers
 
@@ -14,8 +14,8 @@ MCP memory server — mem0 + pgvector + Ollama embeddings
 
 ## Source Code
 
-* <https://github.com/janip81/helm-charts/tree/main/charts/claude-memory/>
-* <https://github.com/janip81/claude-memory>
+* <https://github.com/janip81/helm-charts/tree/main/charts/remnant/>
+* <https://github.com/janip81/remnant>
 
 # Overview
 
@@ -94,23 +94,35 @@ The `s3CredentialsSecret` must contain keys: `access-key-id`, `secret-access-key
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| auth.secretName | string | `"claude-memory-auth"` | Name of the Secret containing BEARER_TOKEN (pre-created or rendered by AVP) |
-| cnpg.backup.destinationPath | string | `"s3://my-bucket/claude-memory"` | S3 destination path |
+| auth.secretName | string | `"remnant-auth"` | Name of the Secret containing BEARER_TOKEN (pre-created or rendered by AVP) |
+| cnpg.backup.destinationPath | string | `"s3://my-bucket/remnant"` | S3 destination path |
 | cnpg.backup.enabled | bool | `false` | Enable Barman S3 backup |
 | cnpg.backup.endpointURL | string | `"https://s3.example.com"` | S3 endpoint URL |
 | cnpg.backup.retentionPolicy | string | `"30d"` | Backup retention policy |
 | cnpg.backup.s3CredentialsSecret | string | `"cnpg-barman-s3-creds"` | Name of the Secret containing S3 credentials (keys: access-key-id, secret-access-key, region) |
+| cnpg.database | string | `"remnant"` | PostgreSQL database name (also used as the owner role name for new clusters) |
 | cnpg.enabled | bool | `true` | Enable CNPG PostgreSQL cluster |
 | cnpg.instances | int | `1` | Number of CNPG instances |
+| cnpg.owner | string | `"remnant"` | PostgreSQL owner role (override to match existing cluster if migrating) |
 | cnpg.storage.size | string | `"5Gi"` | Storage size for the CNPG cluster |
 | cnpg.storage.storageClass | string | `""` | Storage class for the CNPG cluster |
+| dedup.enabled | bool | `true` | Enable the deduplication CronJob |
+| dedup.resources.limits.cpu | string | `"500m"` |  |
+| dedup.resources.limits.memory | string | `"256Mi"` |  |
+| dedup.resources.requests.cpu | string | `"100m"` |  |
+| dedup.resources.requests.memory | string | `"128Mi"` |  |
+| dedup.schedule | string | `"30 3 * * *"` | Cron schedule (default: 03:30 daily, after CNPG backup window) |
+| dedup.semanticThreshold | string | `"0.92"` | Cosine similarity threshold for semantic near-dedup (0–1, higher = stricter) |
+| dedup.suspend | bool | `false` | Suspend the CronJob without deleting it |
 | gatewayApi.enabled | bool | `true` | Enable Gateway API HTTPRoute |
-| gatewayApi.host | string | `"mem0-mcp.prod.example.com"` | Hostname for the MCP HTTPRoute |
+| gatewayApi.host | string | `"remnant-mcp.prod.example.com"` | Hostname for the MCP HTTPRoute |
 | gatewayApi.parentRefs | list | `[{"name":"internal-shared","namespace":"kube-system"}]` | Gateway parentRefs |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"ghcr.io/janip81/claude-memory"` | Image repository |
+| image.repository | string | `"ghcr.io/janip81/remnant"` | Image repository |
 | image.tag | string | `"latest"` | Image tag |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries (e.g. ghcr.io) |
+| mem0.agentId | string | `"default"` | Default agent ID tag (overridden per client via X-Agent-ID header) |
+| mem0.infer | string | `"true"` | Enable LLM extraction and deduplication on add_memory calls |
 | mem0.userId | string | `"default"` | User ID namespace for stored memories |
 | ollama.baseUrl | string | `"http://ollama:11434"` | Ollama server URL |
 | ollama.embedModel | string | `"nomic-embed-text"` | Embedding model (must be pulled in Ollama) |
@@ -122,8 +134,18 @@ The `s3CredentialsSecret` must contain keys: `access-key-id`, `secret-access-key
 | resources.requests.memory | string | `"256Mi"` | Memory request |
 | service.port | int | `8080` | Service port |
 | service.type | string | `"ClusterIP"` | Service type |
-| ui.enabled | bool | `true` | Enable the memory browser UI (separate pod, same image) |
+| serviceMonitor.clusterLabel | string | `""` | Value for the k8s_cluster relabel (defaults to Release.Namespace if unset) |
+| serviceMonitor.enabled | bool | `false` | Enable Prometheus ServiceMonitor |
+| serviceMonitor.interval | string | `"30s"` | Scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional labels (e.g. release: my-prometheus) to match your Prometheus operator selector |
+| serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout |
+| tagging.llmModel | string | `""` | Override LLM model for tagging (empty = use ollama.model) |
+| tagging.mode | string | `"keyword"` | Tagging mode: keyword (fast, rules-only), llm (Ollama at write time), hybrid (keyword at write + LLM nightly) |
+| ui.enabled | bool | `true` | Enable the memory browser UI (separate pod, separate image) |
 | ui.host | string | `""` | Hostname for the UI HTTPRoute (leave empty to share MCP hostname with path routing) |
+| ui.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| ui.image.repository | string | `"ghcr.io/janip81/remnant-ui"` | UI image repository (separate from MCP image) |
+| ui.image.tag | string | `"latest"` | Image tag |
 | ui.port | int | `8081` | Port the UI listens on inside the container |
 | ui.resources.limits.cpu | string | `"200m"` |  |
 | ui.resources.limits.memory | string | `"128Mi"` |  |

--- a/charts/remnant/templates/configmap-settings.yaml
+++ b/charts/remnant/templates/configmap-settings.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "remnant.fullname" . }}-settings
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "remnant.labels" . | nindent 4 }}
+data:
+  TAGGING_MODE: {{ .Values.tagging.mode | quote }}
+  TAGGING_LLM_MODEL: {{ .Values.tagging.llmModel | default "" | quote }}

--- a/charts/remnant/templates/cronjob-dedup.yaml
+++ b/charts/remnant/templates/cronjob-dedup.yaml
@@ -65,6 +65,9 @@ spec:
                 - src/scripts/dedup_job.py
                 - --threshold
                 - {{ .Values.dedup.semanticThreshold | quote }}
+              envFrom:
+                - configMapRef:
+                    name: {{ include "remnant.fullname" . }}-settings
               env:
                 - name: DB_PASSWORD
                   valueFrom:

--- a/charts/remnant/templates/deployment.yaml
+++ b/charts/remnant/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "remnant.fullname" . }}-settings
           env:
             - name: APP_PORT
               value: "8080"

--- a/charts/remnant/values.yaml
+++ b/charts/remnant/values.yaml
@@ -99,6 +99,12 @@ dedup:
       cpu: 500m
       memory: 256Mi
 
+tagging:
+  # -- Tagging mode: keyword (fast, rules-only), llm (Ollama at write time), hybrid (keyword at write + LLM nightly)
+  mode: keyword
+  # -- Override LLM model for tagging (empty = use ollama.model)
+  llmModel: ""
+
 serviceMonitor:
   # -- Enable Prometheus ServiceMonitor
   enabled: false


### PR DESCRIPTION
## Summary

- **Settings ConfigMap** (`configmap-settings.yaml`) — exposes `TAGGING_MODE` and `TAGGING_LLM_MODEL` as env vars to both the MCP Deployment and dedup CronJob via `envFrom`
- **`tagging` values block** — `tagging.mode` (keyword|llm|hybrid) and `tagging.llmModel`
- **Chart version** bumped 0.2.2 → 0.2.3

## New behaviour

| Mode | Write-time | Nightly job |
|------|-----------|-------------|
| `keyword` | rules dict only, instant | Phase 0 skipped |
| `llm` | Ollama call per write | Phase 0 LLM tags untagged memories |
| `hybrid` | rules dict first, instant | Phase 0 fills in anything keyword missed |

Tag rules dictionary is now stored in the `tag_rules` PostgreSQL table (created at MCP startup, seeded from hardcoded defaults). The nightly job logs every phase to a `job_runs` table.

## Test plan

- [ ] Deploy with `tagging.mode: keyword` — verify TAGGING_MODE env var is set in pod
- [ ] Deploy with `tagging.mode: hybrid` — verify CronJob also gets the env var
- [ ] Manually trigger dedup CronJob — verify job_runs rows appear in DB
- [ ] Check `/api/tag-rules` returns seeded rules
- [ ] Check `/api/jobs` returns job run history