### PR TITLE
chore(claude-memory): 0.1.10 — helm-docs README refresh

### DIFF
--- a/charts/claude-memory/Chart.yaml
+++ b/charts/claude-memory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: claude-memory
 description: MCP memory server — mem0 + pgvector + Ollama embeddings
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "0.1.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/claude-memory
 keywords:

--- a/charts/claude-memory/README.md
+++ b/charts/claude-memory/README.md
@@ -1,6 +1,6 @@
 # claude-memory
 
-![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 MCP memory server — mem0 + pgvector + Ollama embeddings
 


### PR DESCRIPTION
Version bump to satisfy ct lint after README was regenerated by full helm-docs run in PR #153.