### PR TITLE
feat(zomboid-server): add Project Zomboid dedicated server Helm chart — 0.1.0

### DIFF
--- a/charts/zomboid-server/.helmignore
+++ b/charts/zomboid-server/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: zomboid-server
+description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "41.78.19"
+home: https://projectzomboid.com
+icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png
+maintainers:
+  - name: janip81
+    email: jani@techmonkeys.se
+keywords:
+  - game
+  - zomboid
+  - project-zomboid
+  - gameserver
+  - dedicated-server
+sources:
+  - https://github.com/Danixu/project-zomboid-server-docker
+  - https://github.com/fpsacha/zomboid-control-panel
+  - https://github.com/janip81/helm-charts/tree/main/charts/zomboid-server
+deprecated: false
+annotations:
+  artifacthub.io/links: |
+    - name: Server image source
+      url: https://github.com/Danixu/project-zomboid-server-docker
+    - name: Panel image source
+      url: https://github.com/fpsacha/zomboid-control-panel
+  artifacthub.io/images: |
+    - name: zomboid-server
+      image: danixu86/project-zomboid-dedicated-server:41.78.19-release
+    - name: zomboid-panel
+      image: ghcr.io/fpsacha/zomboid-panel:v1.0.66

--- a/charts/zomboid-server/LICENSE
+++ b/charts/zomboid-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 janip81
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,0 +1,740 @@
+# zomboid-server
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
+
+A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
+
+**Homepage:** <https://projectzomboid.com>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| janip81 | <jani@techmonkeys.se> |  |
+
+## Source Code
+
+* <https://github.com/Danixu/project-zomboid-server-docker>
+* <https://github.com/fpsacha/zomboid-control-panel>
+* <https://github.com/janip81/helm-charts/tree/main/charts/zomboid-server>
+
+## Overview
+
+This Helm chart deploys a [Project Zomboid](https://projectzomboid.com) dedicated server on Kubernetes as a single-replica StatefulSet.
+
+**Server image:** [`danixu86/project-zomboid-dedicated-server`](https://hub.docker.com/r/danixu86/project-zomboid-dedicated-server) — full RCON, Workshop, Build 41/42 multi-branch support.
+
+**Web panel:** [`ghcr.io/fpsacha/zomboid-panel`](https://github.com/fpsacha/zomboid-control-panel) (Zomboid Control Panel v1.0.66) — a purpose-built PZ admin dashboard with RCON console, live world map, mod manager, player management, backups, and scheduler. Runs as a sidecar with no Docker socket.
+
+## Prerequisites
+
+- Kubernetes 1.29+
+- Helm 3.16+
+- Cilium with Gateway API support (for panel HTTPRoute)
+- Cilium LoadBalancer IP pool (for game traffic)
+- vSphere CSI or another `ReadWriteOnce`-capable StorageClass
+- ArgoCD (optional, for GitOps deployment)
+
+## TL;DR
+
+```bash
+helm repo add janip81 https://janip81.github.io/helm-charts/
+helm install zomboid janip81/zomboid-server -n games --create-namespace \
+  --set zomboid.adminPassword=changeme \
+  --set zomboid.rconPassword=changeme-rcon
+```
+
+## Installation
+
+### Required Secrets
+
+**Never put passwords in Git.** Create the Kubernetes Secret before deploying:
+
+```bash
+kubectl create secret generic zomboid-secrets -n games \
+  --from-literal=admin-password='<strong-admin-password>' \
+  --from-literal=rcon-password='<strong-rcon-password>' \
+  --from-literal=server-password=''
+```
+
+Then reference it in values:
+
+```yaml
+zomboid:
+  existingSecret: "zomboid-secrets"
+  secretKeys:
+    adminPassword: "admin-password"
+    rconPassword: "rcon-password"
+    serverPassword: "server-password"
+```
+
+The RCON password is automatically shared with the panel sidecar — no separate panel secret is needed. The panel creates its own admin account on first run via the setup wizard.
+
+### Install with values file
+
+```bash
+helm upgrade --install zomboid janip81/zomboid-server \
+  -n games --create-namespace \
+  -f examples/values-prod.yaml
+```
+
+## Server Container Security Context
+
+The `danixu86` entrypoint requires root at startup. It performs operations roughly equivalent to:
+
+```bash
+chown -R 1000:1000 /home/steam/pz-dedicated/steamapps/workshop /home/steam/Zomboid
+chmod 755 /home/steam/Zomboid
+su - steam -c "... ./start-server.sh ..."
+```
+
+These steps are incompatible with a restricted container security context:
+
+| Restriction | Effect |
+|-------------|--------|
+| `runAsUser: 1000` | Entrypoint runs as steam; cannot chown files owned by root (PVC first-mount) |
+| `runAsNonRoot: true` | Prevents entrypoint from starting as root |
+| `capabilities.drop: [ALL]` | Removes `CAP_CHOWN`, breaking the chown step |
+
+**The server container security context is therefore left empty (`{}`) by default.** The entrypoint drops to the steam user on its own after initialization.
+
+Do not add `runAsUser`, `runAsNonRoot`, or `capabilities.drop` to the server security context unless you have tested the exact danixu86 image and confirmed the entrypoint completes successfully with those restrictions.
+
+The **panel sidecar** does not run an entrypoint that requires root and uses the more restrictive defaults:
+
+```yaml
+securityContext:
+  panel:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
+```
+
+## Build 41 vs Build 42
+
+The server image bakes the branch **at image-build time**. Select the build by choosing the image tag — there is no runtime environment variable for this.
+
+| Build | Tag | Status |
+|-------|-----|--------|
+| Build 41 (stable) | `41.78.19-release` | Recommended for production |
+| Build 42 (early access) | `42.19.0-unstable` | May have breaking changes |
+
+```yaml
+# Build 41 stable (default)
+image:
+  tag: "41.78.19-release"
+
+# Build 42 early access
+image:
+  tag: "42.19.0-unstable"
+```
+
+> **Warning:** Never switch branches while a world is running. Take a VolumeSnapshot before any branch change.
+> Local and dedicated server branches must match exactly for clients to connect.
+
+## Admin Password Bootstrap
+
+The `danixu86` image passes `ADMINPASSWORD` as a command-line argument. The server logs the full argument list on every startup, exposing the password in plain text.
+
+The chart uses a bootstrap pattern to limit this exposure:
+
+```yaml
+zomboid:
+  adminPasswordBootstrap:
+    enabled: true  # required for first run; set false afterwards
+```
+
+**Workflow:**
+
+1. Deploy with `adminPasswordBootstrap.enabled: true`. The admin account is created.
+2. Log into the server or panel and verify the admin account works.
+3. Set `adminPasswordBootstrap.enabled: false` in values.
+4. Upgrade the chart and delete the pod to apply:
+   ```bash
+   kubectl delete pod -n games zomboid-0
+   ```
+5. From this point forward, `ADMINPASSWORD` is not injected into the process and will not appear in logs.
+
+The RCON password is always injected from the Secret regardless of this setting.
+
+## Workshop Mod Configuration
+
+```yaml
+zomboid:
+  selfManagedMods: false
+  mods:
+    workshopIds:
+      - "2392709985"
+      - "2458631365"
+    modIds:
+      - "MyMod"
+      - "AnotherMod"
+```
+
+> **Critical:** When `selfManagedMods: false` and both lists are empty, the entrypoint sets `SELF_MANAGED_MODS=true` automatically to protect existing INI mod config. If you explicitly set mods in values, `WORKSHOP_IDS` and `MOD_IDS` are passed to the entrypoint, which writes them into the server INI. Switching between these modes on a live server will override the INI on the next restart.
+
+The environment variable the chart sets is `SELF_MANAGED_MODS` (with underscore). This is the correct spelling accepted by the `danixu86` entrypoint.
+
+### Handing mod management to the panel
+
+After your mod list is stable:
+
+```yaml
+zomboid:
+  selfManagedMods: true
+```
+
+This prevents the entrypoint from overwriting the INI mod entries, so panel-managed changes survive restarts.
+
+## Web Panel
+
+The Zomboid Control Panel (`ghcr.io/fpsacha/zomboid-panel`) runs as a sidecar at port 3001. It connects to the game server via RCON at `127.0.0.1:27015` (internal to the pod). RCON is never exposed as a Kubernetes Service.
+
+### RCON_SKIP_SERVER_CHECK
+
+The panel expects to detect the PZ server process before accepting RCON connections. In a Kubernetes sidecar deployment, the panel cannot see the server container's process list — they run in separate container namespaces despite sharing the pod network. The panel would therefore always report the server as offline and refuse RCON commands.
+
+`RCON_SKIP_SERVER_CHECK=true` is set by default to bypass this check. RCON connections and all RCON commands function normally regardless of the process-detection status.
+
+```yaml
+panel:
+  rcon:
+    host: "127.0.0.1"   # always 127.0.0.1 in the sidecar pod
+    port: 27015          # must match zomboid.rcon.port
+    skipServerCheck: true  # required for sidecar deployment
+```
+
+### Panel mounts
+
+The panel reads PZ paths from two shared volume mounts:
+
+| Volume | Server path | Panel path | Access |
+|--------|------------|------------|--------|
+| `data` PVC | `/home/steam/Zomboid` | `/zomboid` | Writable (PanelBridge IPC) |
+| `serverFiles` PVC | `/home/steam/pz-dedicated` | `/pz-server` | Read-only by default |
+
+### Accessing the panel
+
+With Gateway API:
+```yaml
+gateway:
+  enabled: true
+  hostname: "zomboid.example.com"
+  parentRefs:
+    - name: main-gateway
+      namespace: gateway
+panel:
+  corsOrigins: "https://zomboid.example.com"
+  https: true
+```
+
+Via port-forward (no gateway):
+```bash
+kubectl port-forward -n games sts/zomboid-0 3001:3001
+# Open http://localhost:3001
+```
+
+### What the panel can and cannot do
+
+The panel's **Start**, **Stop**, and **Restart** server buttons cannot control the Kubernetes pod. Do not confuse the panel's **Stop** button with issuing the RCON `quit` command from the panel's RCON console — they are different things.
+
+The panel **can** do the following via its RCON console: `save`, `quit`, `players`, `kick`, `ban`, `unban`, `broadcast`, `adduser`, `setaccesslevel`, weather and event commands, and all other PZ RCON commands.
+
+The panel **cannot**:
+- Start or stop the PZ process (Kubernetes owns the container lifecycle)
+- Restart the server on crash (Kubernetes StatefulSet controller handles that)
+- Auto-update the PZ server binary (managed by image tag + pod replacement)
+- Access the Docker socket (not mounted; not needed)
+- Accurately report server process status (status indicator will show offline — this is expected)
+
+### Panel backup storage
+
+The panel stores backups created through its UI inside `/app/data` — the same directory as its database, JWT secret, and configuration.
+
+**Risk with the default 2Gi `panelData` PVC:** frequent large world backups via the panel will fill this volume. Once full, the panel process may fail to write its database.
+
+Recommended approaches:
+1. **Chart CronJob** (enabled via `backup.enabled: true`) — writes to the `backups` PVC (30Gi), not `panelData`
+2. **CSI VolumeSnapshot** after a confirmed RCON save — storage-level snapshot
+3. **Send save via RCON console, then trigger CronJob manually:**
+   ```bash
+   # 1. Issue `save` in the panel RCON console and wait for the save to complete in logs
+   # 2. Trigger the backup job immediately:
+   kubectl create job \
+     --from=cronjob/zomboid-backup \
+     zomboid-backup-manual-$(date +%s) \
+     -n games
+   ```
+4. **Increase `panelData` size** before enabling frequent panel backups:
+   ```yaml
+   persistence:
+     panelData:
+       size: 10Gi
+   ```
+
+The `backups` PVC (mounted at `/backups` in the server container) is used **only** by the chart CronJob — the panel does **not** write into it.
+
+### PanelBridge (optional, disabled by default)
+
+PanelBridge is a server-side Lua mod that enables features beyond RCON: teleport, heal, weather control at granular level, character export/import, inventory editing.
+
+**Requirements:**
+
+1. Make `/pz-server` writable in the panel (needed to install the Lua file):
+   ```yaml
+   panel:
+     panelBridge:
+       enabled: true
+     serverFilesReadOnly: false
+   ```
+
+2. `DoLuaChecksum=false` in the server INI. Set this via the panel's Settings → Server Config editor. This cannot be set via a Helm value — it must be changed in the INI directly.
+
+3. Enable PanelBridge in **Settings → PanelBridge** in the panel UI and restart the PZ server.
+
+Verify the actual path in your running container before enabling PanelBridge:
+
+```bash
+kubectl exec -n games <pod-name> -c server -- \
+  find /home/steam/pz-dedicated -path "*/Install/media/lua/server" -type d
+```
+
+PanelBridge communicates via JSON files in `/zomboid/Lua/panelbridge/<serverName>/` — on the `data` PVC, already writable for the panel at `/zomboid`.
+
+## Planned Maintenance: Safe Shutdown Procedure
+
+> **Important:** The current upstream image (`danixu86/project-zomboid-dedicated-server`) does not install a verified Kubernetes-aware SIGTERM handler. A plain pod deletion or `kubectl scale --replicas=0` may terminate the Java process without flushing a final world save. Do not rely on Kubernetes pod termination alone to produce an application-consistent save.
+
+Use this procedure before any planned maintenance: pod deletion, chart upgrade, scale-down, or VolumeSnapshot.
+
+**Steps:**
+
+1. Open the Zomboid panel and navigate to the RCON console.
+
+2. Issue the save command:
+   ```
+   save
+   ```
+   Wait until the server logs confirm the save completed. Watch the logs:
+   ```bash
+   kubectl logs -n games <pod-name> -c server --tail=100 -f
+   ```
+
+3. Issue the quit command:
+   ```
+   quit
+   ```
+   The game process will exit. The panel RCON console will lose connectivity — this is expected.
+
+4. Confirm from the server logs that the game process has exited before proceeding.
+
+5. Now delete the pod or scale to zero:
+   ```bash
+   # For pod replacement (e.g., applying a chart upgrade):
+   kubectl delete pod -n games zomboid-0
+
+   # For full stop:
+   kubectl scale statefulset -n games zomboid --replicas=0
+   ```
+
+> **Note:** After `quit` is issued through RCON, Kubernetes will detect that the container exited and will recreate it (StatefulSet controller). If you do not want an immediate restart, scale to zero before issuing `quit`, or delete the pod immediately after the process exits.
+
+## Graceful Shutdown Configuration
+
+```yaml
+shutdown:
+  graceful:
+    enabled: false
+    method: "none"
+```
+
+`shutdown.graceful.enabled: false` is the only correct default. There is currently no verified RCON client inside the `danixu86` image container, so no preStop hook is rendered.
+
+A future release may support `method: "rcon"` once a client binary is confirmed present in the image and the full save-then-quit flow is tested end-to-end. Until then, follow the manual maintenance procedure above.
+
+**The chart does not provide a preStop hook.** Kubernetes sends SIGTERM to all containers after the pod is marked for deletion. The pod will be SIGKILL'd after `terminationGracePeriodSeconds` (90 s) regardless of whether the game has saved. This is why the manual save-before-delete procedure is necessary.
+
+## Upgrades
+
+### Chart upgrade procedure
+
+The StatefulSet uses `updateStrategy: OnDelete`. This means:
+- Template changes do **not** automatically restart the running pod.
+- The pod **will** be recreated automatically by Kubernetes on crash, node failure, or eviction.
+
+To apply a chart upgrade:
+
+1. Follow the safe shutdown procedure above to save the world first.
+
+2. Take a VolumeSnapshot before any significant upgrade:
+   ```bash
+   helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml \
+     --set volumeSnapshot.enabled=true
+   helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml \
+     --set volumeSnapshot.enabled=false
+   ```
+
+3. Upgrade the chart:
+   ```bash
+   helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml
+   ```
+
+4. Delete the pod to apply the updated StatefulSet template:
+   ```bash
+   kubectl delete pod -n games zomboid-0
+   ```
+   The StatefulSet controller immediately recreates it using the updated spec.
+
+5. Watch logs to confirm startup:
+   ```bash
+   kubectl logs -f -n games zomboid-0 -c server
+   ```
+
+## Save Migration from Windows
+
+### Pre-migration checklist
+
+- [ ] Stop the Windows server cleanly before copying files
+- [ ] Branches must match (both B41 or both B42)
+- [ ] Mod list and load order must be identical
+- [ ] Take a VolumeSnapshot before the first dedicated-server startup with migrated saves
+
+### Source paths (Windows)
+
+```
+C:\Users\<username>\Zomboid\
+  Saves\Multiplayer\<serverName>\
+  Server\<serverName>.ini
+  Server\<serverName>_SandboxVars.lua
+  Server\<serverName>_spawnpoints.lua
+  Server\<serverName>_spawnregions.lua
+  db\
+```
+
+### Migration procedure
+
+1. Stop the Windows server cleanly.
+
+2. Scale the StatefulSet to zero:
+   ```bash
+   kubectl scale sts zomboid -n games --replicas=0
+   ```
+
+3. Enable the migration helper pod:
+   ```yaml
+   migration:
+     enabled: true
+   ```
+   ```bash
+   helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml
+   kubectl wait --for=condition=Ready pod/zomboid-migration -n games
+   ```
+
+4. Copy saves:
+   ```bash
+   kubectl cp "C:/Users/<user>/Zomboid/Saves/Multiplayer/<serverName>" \
+     games/zomboid-migration:/home/steam/Zomboid/Saves/Multiplayer/<serverName>
+   kubectl cp "C:/Users/<user>/Zomboid/Server" \
+     games/zomboid-migration:/home/steam/Zomboid/Server
+   kubectl cp "C:/Users/<user>/Zomboid/db" \
+     games/zomboid-migration:/home/steam/Zomboid/db
+   ```
+
+5. Fix ownership:
+   ```bash
+   kubectl exec -it -n games zomboid-migration -- \
+     chown -R 1000:1000 /home/steam/Zomboid
+   ```
+
+6. Disable migration and restart:
+   ```yaml
+   migration:
+     enabled: false
+   ```
+   ```bash
+   helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml
+   kubectl scale sts zomboid -n games --replicas=1
+   ```
+
+7. Watch logs and confirm world + character load correctly.
+
+Keep the same `serverName` as on Windows. Changing it creates a new world.
+
+## Backups
+
+### CronJob (crash-consistent)
+
+The built-in CronJob reads live files from the data PVC without coordinating a save with the running server. **Backups are crash-consistent, not application-consistent.** Files copied while the server is mid-write may be incomplete.
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 4 * * *"
+  retentionDays: 7
+```
+
+Archives are written to the `backups` PVC at `/backups/<serverName>-YYYYMMDD-HHMMSS.tar.gz`.
+
+Trigger a manual run immediately after an RCON save:
+```bash
+kubectl create job \
+  --from=cronjob/zomboid-backup \
+  zomboid-backup-manual-$(date +%s) \
+  -n games
+```
+
+### CSI VolumeSnapshots
+
+A CSI snapshot taken without a prior RCON save is still crash-consistent. For improved consistency, issue `save` through the RCON console first and wait for confirmation — then take the snapshot immediately:
+
+```bash
+# After confirmed RCON save:
+helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml \
+  --set volumeSnapshot.enabled=true
+helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml \
+  --set volumeSnapshot.enabled=false
+```
+
+For the safest pre-maintenance snapshot:
+1. Issue `save` via RCON console.
+2. Issue `quit` via RCON console.
+3. Confirm the server has stopped (logs show exit).
+4. Take the VolumeSnapshot.
+5. Restart or delete/recreate the pod.
+
+Take snapshots before:
+- Server version upgrade
+- Branch switch (B41 ↔ B42)
+- Large mod list changes
+- World migration from another host
+- Panel upgrades
+
+## First-Deployment Shutdown Test
+
+Before committing a world to production, verify shutdown behavior with this test (use a disposable test world):
+
+1. Start the server and enter the game.
+2. Place or move a recognizable object.
+3. Send `save` through the panel RCON console:
+   ```bash
+   kubectl logs -n games zomboid-0 -c server --tail=100 -f
+   ```
+   Wait until logs confirm the save completed.
+4. Send `quit` through the RCON console.
+5. Confirm a clean exit in the logs.
+6. Delete/recreate the pod:
+   ```bash
+   kubectl delete pod -n games zomboid-0
+   ```
+7. Re-enter the game and verify the object placement survived.
+
+**Separately** (on a disposable world only), test a plain pod deletion without a prior RCON quit:
+```bash
+kubectl delete pod -n games zomboid-0
+```
+Check whether the last auto-save survived. Do **not** rely on this for production worlds until the behavior is confirmed repeatable. Do not update chart documentation to claim graceful SIGTERM handling unless this test passes consistently.
+
+## Cilium LoadBalancer Configuration
+
+```yaml
+service:
+  game:
+    type: LoadBalancer
+    loadBalancerIP: "192.168.101.50"
+    externalTrafficPolicy: Local
+    ports:
+      game: 16261
+      direct: 16262
+    steamPorts:
+      enabled: false   # enable for Steam client discovery (ports 8766, 8767 UDP)
+```
+
+`externalTrafficPolicy: Local` is recommended for a single-replica StatefulSet.
+
+Steam discovery ports (8766/8767 UDP) are disabled by default. Enable them if players use the Steam server browser rather than direct connect.
+
+## Troubleshooting
+
+### Volume ownership errors
+
+```bash
+kubectl exec -it zomboid-0 -n games -c server -- ls -la /home/steam/Zomboid
+```
+
+All files should be owned `1000:1000`. If not, fix with the migration pod:
+```bash
+kubectl exec -it -n games zomboid-migration -- chown -R 1000:1000 /home/steam/Zomboid
+```
+
+### Workshop downloads failing
+
+Mods install on the **second** server start. If they fail repeatedly:
+- Check logs for Steam auth errors.
+- Add `FORCESTEAMCLIENTSOUPDATE=true` via `zomboid.extraEnv` for one restart.
+- Verify the server node can reach Steam (8766/8767 UDP outbound).
+
+### Panel RCON shows server offline
+
+This is expected. The panel cannot detect the PZ process in the server container namespace. `RCON_SKIP_SERVER_CHECK=true` is set automatically — RCON commands work regardless.
+
+### Missing player after migration
+
+- The `db/` directory must have been copied completely.
+- The `serverName` must match exactly (case-sensitive).
+- Check logs for `LoadPlayerData`.
+
+### Panel data PVC full
+
+```bash
+kubectl exec -it zomboid-0 -n games -c panel -- df -h /app/data
+```
+
+If full from panel-created backups:
+```bash
+kubectl exec -it zomboid-0 -n games -c panel -- \
+  find /app/data/backups -name "*.zip" -mtime +7 -delete
+```
+Then increase `persistence.panelData.size` before re-enabling panel backups.
+
+### Why replicas must remain at 1
+
+PZ saves are single-file-per-world. Two replicas writing to the same PVC would corrupt the save. The chart hardcodes `replicas: 1`.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod scheduling |
+| backup.enabled | bool | `false` | Enable the backup CronJob |
+| backup.image.pullPolicy | string | `"IfNotPresent"` |  |
+| backup.image.repository | string | `"alpine"` | Image used for backup scripts (needs tar, find, date) |
+| backup.image.tag | string | `"3.19"` |  |
+| backup.retentionDays | int | `7` | Number of days to retain backup archives |
+| backup.schedule | string | `"0 4 * * *"` | Cron schedule for backups |
+| fullnameOverride | string | `""` | Provide a full name override for chart resources |
+| gateway.annotations | object | `{}` | Annotations on the HTTPRoute resource |
+| gateway.enabled | bool | `false` | Enable the HTTPRoute for the panel |
+| gateway.hostname | string | `"zomboid.example.com"` | Hostname the panel should be reachable on |
+| gateway.parentRefs | list | `[{"name":"main-gateway","namespace":"gateway"}]` | Parent gateway references |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"danixu86/project-zomboid-dedicated-server","tag":"41.78.19-release"}` | Docker image for the Project Zomboid dedicated server. Build 41 vs Build 42 is determined by the image tag — STEAMAPPBRANCH is baked at build time. Build 41 (stable):       danixu86/project-zomboid-dedicated-server:41.78.19-release Build 42 (early access): danixu86/project-zomboid-dedicated-server:42.19.0-unstable |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"danixu86/project-zomboid-dedicated-server"` | Docker repository for the server image |
+| image.tag | string | 41.78.19-release (Build 41 stable) | Image tag. Pin to a specific version; floating tags are discouraged in production. |
+| livenessProbe.enabled | bool | `false` | Enable liveness probe |
+| livenessProbe.failureThreshold | int | `6` |  |
+| livenessProbe.initialDelaySeconds | int | `300` |  |
+| livenessProbe.periodSeconds | int | `30` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| migration.enabled | bool | `false` | Enable the migration helper pod |
+| migration.image.pullPolicy | string | `"IfNotPresent"` |  |
+| migration.image.repository | string | `"busybox"` | Image used by the migration pod |
+| migration.image.tag | string | `"1.36"` |  |
+| nameOverride | string | `""` | Provide a name override for chart resources |
+| nodeSelector | object | `{}` | Node selector for pod scheduling |
+| panel.corsOrigins | string | `""` | CORS allowed origins. Required when the panel is behind a reverse proxy. Set to the full URL the panel is accessed from, e.g. "https://zomboid.example.com". Leave empty for LAN/localhost access (private IPs are allowed automatically). |
+| panel.enabled | bool | `true` | Enable the Zomboid Control Panel sidecar |
+| panel.extraEnv | list | `[]` | Extra environment variables for the panel container |
+| panel.https | bool | `true` | Set true when the panel is served over HTTPS by a reverse proxy (Gateway API). Enables HSTS and upgrade-insecure-requests security headers. |
+| panel.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| panel.image.repository | string | `"ghcr.io/fpsacha/zomboid-panel"` | Panel image repository |
+| panel.image.tag | string | `"v1.0.66"` | Panel image tag (pin to a specific release in production) |
+| panel.logLevel | string | `"info"` | Winston log level for the panel process (error, warn, info, debug) |
+| panel.panelBridge.enabled | bool | `false` | Enable PanelBridge integration (requires DoLuaChecksum=false and write access to /pz-server) |
+| panel.port | int | `3001` | Panel HTTP port |
+| panel.rcon.host | string | `"127.0.0.1"` | Hostname the panel uses to reach the game server RCON |
+| panel.rcon.port | int | `27015` | RCON port the panel connects to (must match zomboid.rcon.port) |
+| panel.rcon.skipServerCheck | bool | `true` | Allow RCON even when the panel cannot detect the PZ process. Must be true in Kubernetes: the panel sidecar runs in a separate container and cannot inspect the server container's process list. RCON commands still work. |
+| panel.serverFilesReadOnly | bool | `true` | Mount the PZ server install (/pz-server) as read-only in the panel container. Must be set to false when panelBridge.enabled is true, because PanelBridge needs to write PanelBridge.lua into /pz-server/Install/media/lua/server/. |
+| panel.steamApiKey | string | `""` | Optional Steam Web API key for richer mod metadata from the Workshop. See https://steamcommunity.com/dev/apikey |
+| persistence.backups.accessModes | list | `["ReadWriteOnce"]` | Access modes |
+| persistence.backups.enabled | bool | `true` | Enable the backups PVC |
+| persistence.backups.existingClaim | string | `""` | Use an existing PVC instead of creating one |
+| persistence.backups.size | string | `"30Gi"` | Size of the backups PVC |
+| persistence.backups.storageClass | string | `""` | Per-PVC StorageClass override |
+| persistence.data.accessModes | list | `["ReadWriteOnce"]` | Access modes |
+| persistence.data.enabled | bool | `true` | Enable the game data PVC |
+| persistence.data.existingClaim | string | `""` | Use an existing PVC instead of creating one |
+| persistence.data.size | string | `"20Gi"` | Size of the game data PVC |
+| persistence.data.storageClass | string | `""` | Per-PVC StorageClass override |
+| persistence.panelData.accessModes | list | `["ReadWriteOnce"]` | Access modes |
+| persistence.panelData.enabled | bool | `true` | Enable the panel data PVC |
+| persistence.panelData.existingClaim | string | `""` | Use an existing PVC instead of creating one |
+| persistence.panelData.size | string | `"2Gi"` | Size of the panel data PVC. Increase if you intend to use the panel backup feature frequently. |
+| persistence.panelData.storageClass | string | `""` | Per-PVC StorageClass override |
+| persistence.panelLogs.accessModes | list | `["ReadWriteOnce"]` | Access modes |
+| persistence.panelLogs.enabled | bool | `false` | Enable a PVC for panel logs (disabled = emptyDir) |
+| persistence.panelLogs.existingClaim | string | `""` | Use an existing PVC instead of creating one |
+| persistence.panelLogs.size | string | `"2Gi"` | Size of the panel logs PVC |
+| persistence.panelLogs.storageClass | string | `""` | Per-PVC StorageClass override |
+| persistence.serverFiles.accessModes | list | `["ReadWriteOnce"]` | Access modes |
+| persistence.serverFiles.enabled | bool | `true` | Enable the server files PVC |
+| persistence.serverFiles.existingClaim | string | `""` | Use an existing PVC instead of creating one |
+| persistence.serverFiles.size | string | `"30Gi"` | Size of the server files PVC (PZ server binary ~2 GB + workshop mods can be large) |
+| persistence.serverFiles.storageClass | string | `""` | Per-PVC StorageClass override |
+| persistence.storageClass | string | `""` | Default StorageClass for all PVCs (overridable per PVC). Leave "" for cluster default. |
+| podSecurityContext | object | `{"fsGroup":1000}` | Pod-level security context fsGroup 1000 matches the steam/node user GID so mounted PVCs are writable by both containers. |
+| readinessProbe.enabled | bool | `true` | Enable readiness probe |
+| readinessProbe.failureThreshold | int | `10` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `15` |  |
+| readinessProbe.timeoutSeconds | int | `5` |  |
+| resources.panel | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resources for the Zomboid Control Panel sidecar |
+| resources.server | object | `{"limits":{"cpu":"4000m","memory":"8Gi"},"requests":{"cpu":"1000m","memory":"4Gi"}}` | Resources for the game server container |
+| securityContext.panel | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Security context for the Zomboid Control Panel sidecar The panel image is built with UID/GID 1000 (matching the compose default build-arg). Adjust runAsUser if you see permission errors on /app/data or /zomboid. |
+| securityContext.server | object | `{}` | Security context for the game server container.  Left empty intentionally. The danixu86 entrypoint requires root at startup: it runs chown -R 1000:1000 on the mounted PVC directories (requires CAP_CHOWN) then uses `su - steam` to drop to the steam user before launching the server.  These entrypoint operations are INCOMPATIBLE with:   runAsUser: 1000     — entrypoint must start as root   runAsNonRoot: true  — same reason   capabilities.drop: [ALL] — removes CAP_CHOWN, breaking the chown step  Do not set these values unless a real container startup test with the exact danixu86 image confirms that the entrypoint completes successfully. |
+| service.game.annotations | object | `{}` | Annotations for the game service (e.g. Cilium LB pool selector) |
+| service.game.externalTrafficPolicy | string | `"Local"` | externalTrafficPolicy for the game service. Local preserves client source IPs and avoids the double-NAT hop. Correct for a single-replica StatefulSet (traffic only goes to the one pod). |
+| service.game.loadBalancerIP | string | `""` | Static IP from your Cilium LB pool (leave empty for automatic assignment) |
+| service.game.ports | object | `{"direct":16262,"game":16261}` | Required game ports (always exposed) |
+| service.game.ports.direct | int | `16262` | Direct-connect UDP port |
+| service.game.ports.game | int | `16261` | Main game UDP port |
+| service.game.steamPorts.enabled | bool | `false` | Enable Steam discovery ports in the game Service |
+| service.game.steamPorts.port1 | int | `8766` | Steam port 1 |
+| service.game.steamPorts.port2 | int | `8767` | Steam port 2 |
+| service.game.type | string | `"LoadBalancer"` | Game service type. LoadBalancer is required for direct UDP game traffic. |
+| service.panel.port | int | `3001` | Panel service port |
+| service.panel.type | string | `"ClusterIP"` | Panel service type (ClusterIP; exposed externally only via Gateway API) |
+| shutdown.graceful.enabled | bool | `false` | Enable graceful shutdown (no verified method is currently implemented) |
+| shutdown.graceful.method | string | `"none"` | Shutdown method. Currently only "none" is supported. "rcon" may be added in a future release once a client binary is verified to exist inside the danixu86 image and tested end-to-end. |
+| startupProbe.enabled | bool | `true` | Enable startup probe |
+| startupProbe.failureThreshold | int | `40` | How many consecutive failures before the pod is killed (60s + 40*15s = 10 min total) |
+| startupProbe.initialDelaySeconds | int | `60` | Seconds before the first probe fires |
+| startupProbe.periodSeconds | int | `15` | How often to probe |
+| startupProbe.timeoutSeconds | int | `5` | Probe timeout |
+| terminationGracePeriodSeconds | int | `90` | Seconds Kubernetes waits for the pod to shut down cleanly before SIGKILL. The Danixu entrypoint does not install a verified SIGTERM handler that saves the world. A plain pod deletion or scale-to-zero may terminate the server without an explicit save. Before planned maintenance, issue `save` then `quit` via the panel RCON console first. |
+| tolerations | list | `[]` | Tolerations for pod scheduling |
+| volumeSnapshot.data | object | `{"enabled":true}` | Snapshot the game data PVC |
+| volumeSnapshot.enabled | bool | `false` | Enable snapshot creation (requires a CSI driver that supports VolumeSnapshots) |
+| volumeSnapshot.serverFiles | object | `{"enabled":true}` | Snapshot the server files PVC |
+| volumeSnapshot.snapshotClassName | string | `""` | VolumeSnapshotClass name (leave "" for cluster default) |
+| zomboid.adminPassword | string | `""` | Admin password (only used for initial account creation; see adminPasswordBootstrap) |
+| zomboid.adminPasswordBootstrap.enabled | bool | `true` | Inject ADMINPASSWORD from the Secret on startup. Set false after the admin account has been created on first run. |
+| zomboid.adminUsername | string | `"admin"` | Admin username |
+| zomboid.displayName | string | `""` | Display name in the server browser (kept from INI if left empty) |
+| zomboid.existingSecret | string | `""` | Reference an existing Kubernetes Secret instead of creating one. The secret must contain the keys defined in secretKeys. Set to "" to have the chart create a secret from the inline password values below. |
+| zomboid.extraEnv | list | `[]` | Additional environment variables passed to the server container |
+| zomboid.maxMemory | string | `"4096m"` | Maximum JVM heap allocation (e.g. 4096m). Must be below the container memory limit. |
+| zomboid.maxPlayers | int | `16` | Maximum player slots |
+| zomboid.minMemory | string | `"2048m"` | Minimum JVM heap allocation (e.g. 2048m). Falls back to MEMORY if unset. |
+| zomboid.mods.modFolders | string | `"workshop,steam,mods"` | Mod source folders (comma-separated, order matters for load priority) |
+| zomboid.mods.modIds | list | `[]` | Mod IDs to load (list of strings; prefix each with \\ for Build 42) |
+| zomboid.mods.workshopIds | list | `[]` | Steam Workshop item IDs (list of strings, e.g. ["2392709985","2458631365"]) |
+| zomboid.noSteam | bool | `false` | Allow non-Steam clients to connect |
+| zomboid.public | bool | `false` | Show server in the in-game server browser |
+| zomboid.rcon.port | int | `27015` | RCON port (internal only; never exposed outside the pod) |
+| zomboid.rconPassword | string | `""` | RCON password |
+| zomboid.secretKeys | object | `{"adminPassword":"admin-password","rconPassword":"rcon-password","serverPassword":"server-password"}` | Keys within the secret that hold each password |
+| zomboid.secretKeys.adminPassword | string | `"admin-password"` | Key holding the admin password |
+| zomboid.secretKeys.rconPassword | string | `"rcon-password"` | Key holding the RCON password |
+| zomboid.secretKeys.serverPassword | string | `"server-password"` | Key holding the server join password |
+| zomboid.selfManagedMods | bool | `false` | When true, the entrypoint will NOT modify Mods/WorkshopItems in the server INI. Use this after initial mod setup or when managing mods via the web panel. WARNING: when false and workshopIds/modIds are both empty, the entrypoint will CLEAR existing mod config in the INI file on every restart. |
+| zomboid.serverName | string | `"zomboid"` | Server name identifier (no spaces or special characters — admin login will fail) |
+| zomboid.serverPassword | string | `""` | Server join password (leave empty for no password) |
+| zomboid.serverPreset | string | `"Survival"` | Difficulty preset for a new server Options: Apocalypse, Beginner, Builder, FirstWeek, SixMonthsLater, Survival, Survivor |
+| zomboid.serverPresetReplace | bool | `false` | Replace the preset on every container start. Set true only during initial setup; set false afterwards to protect custom INI edits. |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/zomboid-server/README.md.gotmpl
+++ b/charts/zomboid-server/README.md.gotmpl
@@ -1,0 +1,603 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+## Overview
+
+This Helm chart deploys a [Project Zomboid](https://projectzomboid.com) dedicated server on Kubernetes as a single-replica StatefulSet.
+
+**Server image:** [`danixu86/project-zomboid-dedicated-server`](https://hub.docker.com/r/danixu86/project-zomboid-dedicated-server) — full RCON, Workshop, Build 41/42 multi-branch support.
+
+**Web panel:** [`ghcr.io/fpsacha/zomboid-panel`](https://github.com/fpsacha/zomboid-control-panel) (Zomboid Control Panel v1.0.66) — a purpose-built PZ admin dashboard with RCON console, live world map, mod manager, player management, backups, and scheduler. Runs as a sidecar with no Docker socket.
+
+## Prerequisites
+
+- Kubernetes 1.29+
+- Helm 3.16+
+- Cilium with Gateway API support (for panel HTTPRoute)
+- Cilium LoadBalancer IP pool (for game traffic)
+- vSphere CSI or another `ReadWriteOnce`-capable StorageClass
+- ArgoCD (optional, for GitOps deployment)
+
+## TL;DR
+
+```bash
+helm repo add janip81 https://janip81.github.io/helm-charts/
+helm install zomboid janip81/zomboid-server -n games --create-namespace \
+  --set zomboid.adminPassword=changeme \
+  --set zomboid.rconPassword=changeme-rcon
+```
+
+## Installation
+
+### Required Secrets
+
+**Never put passwords in Git.** Create the Kubernetes Secret before deploying:
+
+```bash
+kubectl create secret generic zomboid-secrets -n games \
+  --from-literal=admin-password='<strong-admin-password>' \
+  --from-literal=rcon-password='<strong-rcon-password>' \
+  --from-literal=server-password=''
+```
+
+Then reference it in values:
+
+```yaml
+zomboid:
+  existingSecret: "zomboid-secrets"
+  secretKeys:
+    adminPassword: "admin-password"
+    rconPassword: "rcon-password"
+    serverPassword: "server-password"
+```
+
+The RCON password is automatically shared with the panel sidecar — no separate panel secret is needed. The panel creates its own admin account on first run via the setup wizard.
+
+### Install with values file
+
+```bash
+helm upgrade --install zomboid janip81/zomboid-server \
+  -n games --create-namespace \
+  -f examples/values-prod.yaml
+```
+
+## Server Container Security Context
+
+The `danixu86` entrypoint requires root at startup. It performs operations roughly equivalent to:
+
+```bash
+chown -R 1000:1000 /home/steam/pz-dedicated/steamapps/workshop /home/steam/Zomboid
+chmod 755 /home/steam/Zomboid
+su - steam -c "... ./start-server.sh ..."
+```
+
+These steps are incompatible with a restricted container security context:
+
+| Restriction | Effect |
+|-------------|--------|
+| `runAsUser: 1000` | Entrypoint runs as steam; cannot chown files owned by root (PVC first-mount) |
+| `runAsNonRoot: true` | Prevents entrypoint from starting as root |
+| `capabilities.drop: [ALL]` | Removes `CAP_CHOWN`, breaking the chown step |
+
+**The server container security context is therefore left empty (`{}`) by default.** The entrypoint drops to the steam user on its own after initialization.
+
+Do not add `runAsUser`, `runAsNonRoot`, or `capabilities.drop` to the server security context unless you have tested the exact danixu86 image and confirmed the entrypoint completes successfully with those restrictions.
+
+The **panel sidecar** does not run an entrypoint that requires root and uses the more restrictive defaults:
+
+```yaml
+securityContext:
+  panel:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ALL]
+```
+
+## Build 41 vs Build 42
+
+The server image bakes the branch **at image-build time**. Select the build by choosing the image tag — there is no runtime environment variable for this.
+
+| Build | Tag | Status |
+|-------|-----|--------|
+| Build 41 (stable) | `41.78.19-release` | Recommended for production |
+| Build 42 (early access) | `42.19.0-unstable` | May have breaking changes |
+
+```yaml
+# Build 41 stable (default)
+image:
+  tag: "41.78.19-release"
+
+# Build 42 early access
+image:
+  tag: "42.19.0-unstable"
+```
+
+> **Warning:** Never switch branches while a world is running. Take a VolumeSnapshot before any branch change.
+> Local and dedicated server branches must match exactly for clients to connect.
+
+## Admin Password Bootstrap
+
+The `danixu86` image passes `ADMINPASSWORD` as a command-line argument. The server logs the full argument list on every startup, exposing the password in plain text.
+
+The chart uses a bootstrap pattern to limit this exposure:
+
+```yaml
+zomboid:
+  adminPasswordBootstrap:
+    enabled: true  # required for first run; set false afterwards
+```
+
+**Workflow:**
+
+1. Deploy with `adminPasswordBootstrap.enabled: true`. The admin account is created.
+2. Log into the server or panel and verify the admin account works.
+3. Set `adminPasswordBootstrap.enabled: false` in values.
+4. Upgrade the chart and delete the pod to apply:
+   ```bash
+   kubectl delete pod -n games zomboid-0
+   ```
+5. From this point forward, `ADMINPASSWORD` is not injected into the process and will not appear in logs.
+
+The RCON password is always injected from the Secret regardless of this setting.
+
+## Workshop Mod Configuration
+
+```yaml
+zomboid:
+  selfManagedMods: false
+  mods:
+    workshopIds:
+      - "2392709985"
+      - "2458631365"
+    modIds:
+      - "MyMod"
+      - "AnotherMod"
+```
+
+> **Critical:** When `selfManagedMods: false` and both lists are empty, the entrypoint sets `SELF_MANAGED_MODS=true` automatically to protect existing INI mod config. If you explicitly set mods in values, `WORKSHOP_IDS` and `MOD_IDS` are passed to the entrypoint, which writes them into the server INI. Switching between these modes on a live server will override the INI on the next restart.
+
+The environment variable the chart sets is `SELF_MANAGED_MODS` (with underscore). This is the correct spelling accepted by the `danixu86` entrypoint.
+
+### Handing mod management to the panel
+
+After your mod list is stable:
+
+```yaml
+zomboid:
+  selfManagedMods: true
+```
+
+This prevents the entrypoint from overwriting the INI mod entries, so panel-managed changes survive restarts.
+
+## Web Panel
+
+The Zomboid Control Panel (`ghcr.io/fpsacha/zomboid-panel`) runs as a sidecar at port 3001. It connects to the game server via RCON at `127.0.0.1:27015` (internal to the pod). RCON is never exposed as a Kubernetes Service.
+
+### RCON_SKIP_SERVER_CHECK
+
+The panel expects to detect the PZ server process before accepting RCON connections. In a Kubernetes sidecar deployment, the panel cannot see the server container's process list — they run in separate container namespaces despite sharing the pod network. The panel would therefore always report the server as offline and refuse RCON commands.
+
+`RCON_SKIP_SERVER_CHECK=true` is set by default to bypass this check. RCON connections and all RCON commands function normally regardless of the process-detection status.
+
+```yaml
+panel:
+  rcon:
+    host: "127.0.0.1"   # always 127.0.0.1 in the sidecar pod
+    port: 27015          # must match zomboid.rcon.port
+    skipServerCheck: true  # required for sidecar deployment
+```
+
+### Panel mounts
+
+The panel reads PZ paths from two shared volume mounts:
+
+| Volume | Server path | Panel path | Access |
+|--------|------------|------------|--------|
+| `data` PVC | `/home/steam/Zomboid` | `/zomboid` | Writable (PanelBridge IPC) |
+| `serverFiles` PVC | `/home/steam/pz-dedicated` | `/pz-server` | Read-only by default |
+
+### Accessing the panel
+
+With Gateway API:
+```yaml
+gateway:
+  enabled: true
+  hostname: "zomboid.example.com"
+  parentRefs:
+    - name: main-gateway
+      namespace: gateway
+panel:
+  corsOrigins: "https://zomboid.example.com"
+  https: true
+```
+
+Via port-forward (no gateway):
+```bash
+kubectl port-forward -n games sts/zomboid-0 3001:3001
+# Open http://localhost:3001
+```
+
+### What the panel can and cannot do
+
+The panel's **Start**, **Stop**, and **Restart** server buttons cannot control the Kubernetes pod. Do not confuse the panel's **Stop** button with issuing the RCON `quit` command from the panel's RCON console — they are different things.
+
+The panel **can** do the following via its RCON console: `save`, `quit`, `players`, `kick`, `ban`, `unban`, `broadcast`, `adduser`, `setaccesslevel`, weather and event commands, and all other PZ RCON commands.
+
+The panel **cannot**:
+- Start or stop the PZ process (Kubernetes owns the container lifecycle)
+- Restart the server on crash (Kubernetes StatefulSet controller handles that)
+- Auto-update the PZ server binary (managed by image tag + pod replacement)
+- Access the Docker socket (not mounted; not needed)
+- Accurately report server process status (status indicator will show offline — this is expected)
+
+### Panel backup storage
+
+The panel stores backups created through its UI inside `/app/data` — the same directory as its database, JWT secret, and configuration.
+
+**Risk with the default 2Gi `panelData` PVC:** frequent large world backups via the panel will fill this volume. Once full, the panel process may fail to write its database.
+
+Recommended approaches:
+1. **Chart CronJob** (enabled via `backup.enabled: true`) — writes to the `backups` PVC (30Gi), not `panelData`
+2. **CSI VolumeSnapshot** after a confirmed RCON save — storage-level snapshot
+3. **Send save via RCON console, then trigger CronJob manually:**
+   ```bash
+   # 1. Issue `save` in the panel RCON console and wait for the save to complete in logs
+   # 2. Trigger the backup job immediately:
+   kubectl create job \
+     --from=cronjob/zomboid-backup \
+     zomboid-backup-manual-$(date +%s) \
+     -n games
+   ```
+4. **Increase `panelData` size** before enabling frequent panel backups:
+   ```yaml
+   persistence:
+     panelData:
+       size: 10Gi
+   ```
+
+The `backups` PVC (mounted at `/backups` in the server container) is used **only** by the chart CronJob — the panel does **not** write into it.
+
+### PanelBridge (optional, disabled by default)
+
+PanelBridge is a server-side Lua mod that enables features beyond RCON: teleport, heal, weather control at granular level, character export/import, inventory editing.
+
+**Requirements:**
+
+1. Make `/pz-server` writable in the panel (needed to install the Lua file):
+   ```yaml
+   panel:
+     panelBridge:
+       enabled: true
+     serverFilesReadOnly: false
+   ```
+
+2. `DoLuaChecksum=false` in the server INI. Set this via the panel's Settings → Server Config editor. This cannot be set via a Helm value — it must be changed in the INI directly.
+
+3. Enable PanelBridge in **Settings → PanelBridge** in the panel UI and restart the PZ server.
+
+Verify the actual path in your running container before enabling PanelBridge:
+
+```bash
+kubectl exec -n games <pod-name> -c server -- \
+  find /home/steam/pz-dedicated -path "*/Install/media/lua/server" -type d
+```
+
+PanelBridge communicates via JSON files in `/zomboid/Lua/panelbridge/<serverName>/` — on the `data` PVC, already writable for the panel at `/zomboid`.
+
+## Planned Maintenance: Safe Shutdown Procedure
+
+> **Important:** The current upstream image (`danixu86/project-zomboid-dedicated-server`) does not install a verified Kubernetes-aware SIGTERM handler. A plain pod deletion or `kubectl scale --replicas=0` may terminate the Java process without flushing a final world save. Do not rely on Kubernetes pod termination alone to produce an application-consistent save.
+
+Use this procedure before any planned maintenance: pod deletion, chart upgrade, scale-down, or VolumeSnapshot.
+
+**Steps:**
+
+1. Open the Zomboid panel and navigate to the RCON console.
+
+2. Issue the save command:
+   ```
+   save
+   ```
+   Wait until the server logs confirm the save completed. Watch the logs:
+   ```bash
+   kubectl logs -n games <pod-name> -c server --tail=100 -f
+   ```
+
+3. Issue the quit command:
+   ```
+   quit
+   ```
+   The game process will exit. The panel RCON console will lose connectivity — this is expected.
+
+4. Confirm from the server logs that the game process has exited before proceeding.
+
+5. Now delete the pod or scale to zero:
+   ```bash
+   # For pod replacement (e.g., applying a chart upgrade):
+   kubectl delete pod -n games zomboid-0
+
+   # For full stop:
+   kubectl scale statefulset -n games zomboid --replicas=0
+   ```
+
+> **Note:** After `quit` is issued through RCON, Kubernetes will detect that the container exited and will recreate it (StatefulSet controller). If you do not want an immediate restart, scale to zero before issuing `quit`, or delete the pod immediately after the process exits.
+
+## Graceful Shutdown Configuration
+
+```yaml
+shutdown:
+  graceful:
+    enabled: false
+    method: "none"
+```
+
+`shutdown.graceful.enabled: false` is the only correct default. There is currently no verified RCON client inside the `danixu86` image container, so no preStop hook is rendered.
+
+A future release may support `method: "rcon"` once a client binary is confirmed present in the image and the full save-then-quit flow is tested end-to-end. Until then, follow the manual maintenance procedure above.
+
+**The chart does not provide a preStop hook.** Kubernetes sends SIGTERM to all containers after the pod is marked for deletion. The pod will be SIGKILL'd after `terminationGracePeriodSeconds` (90 s) regardless of whether the game has saved. This is why the manual save-before-delete procedure is necessary.
+
+## Upgrades
+
+### Chart upgrade procedure
+
+The StatefulSet uses `updateStrategy: OnDelete`. This means:
+- Template changes do **not** automatically restart the running pod.
+- The pod **will** be recreated automatically by Kubernetes on crash, node failure, or eviction.
+
+To apply a chart upgrade:
+
+1. Follow the safe shutdown procedure above to save the world first.
+
+2. Take a VolumeSnapshot before any significant upgrade:
+   ```bash
+   helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml \
+     --set volumeSnapshot.enabled=true
+   helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml \
+     --set volumeSnapshot.enabled=false
+   ```
+
+3. Upgrade the chart:
+   ```bash
+   helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml
+   ```
+
+4. Delete the pod to apply the updated StatefulSet template:
+   ```bash
+   kubectl delete pod -n games zomboid-0
+   ```
+   The StatefulSet controller immediately recreates it using the updated spec.
+
+5. Watch logs to confirm startup:
+   ```bash
+   kubectl logs -f -n games zomboid-0 -c server
+   ```
+
+## Save Migration from Windows
+
+### Pre-migration checklist
+
+- [ ] Stop the Windows server cleanly before copying files
+- [ ] Branches must match (both B41 or both B42)
+- [ ] Mod list and load order must be identical
+- [ ] Take a VolumeSnapshot before the first dedicated-server startup with migrated saves
+
+### Source paths (Windows)
+
+```
+C:\Users\<username>\Zomboid\
+  Saves\Multiplayer\<serverName>\
+  Server\<serverName>.ini
+  Server\<serverName>_SandboxVars.lua
+  Server\<serverName>_spawnpoints.lua
+  Server\<serverName>_spawnregions.lua
+  db\
+```
+
+### Migration procedure
+
+1. Stop the Windows server cleanly.
+
+2. Scale the StatefulSet to zero:
+   ```bash
+   kubectl scale sts zomboid -n games --replicas=0
+   ```
+
+3. Enable the migration helper pod:
+   ```yaml
+   migration:
+     enabled: true
+   ```
+   ```bash
+   helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml
+   kubectl wait --for=condition=Ready pod/zomboid-migration -n games
+   ```
+
+4. Copy saves:
+   ```bash
+   kubectl cp "C:/Users/<user>/Zomboid/Saves/Multiplayer/<serverName>" \
+     games/zomboid-migration:/home/steam/Zomboid/Saves/Multiplayer/<serverName>
+   kubectl cp "C:/Users/<user>/Zomboid/Server" \
+     games/zomboid-migration:/home/steam/Zomboid/Server
+   kubectl cp "C:/Users/<user>/Zomboid/db" \
+     games/zomboid-migration:/home/steam/Zomboid/db
+   ```
+
+5. Fix ownership:
+   ```bash
+   kubectl exec -it -n games zomboid-migration -- \
+     chown -R 1000:1000 /home/steam/Zomboid
+   ```
+
+6. Disable migration and restart:
+   ```yaml
+   migration:
+     enabled: false
+   ```
+   ```bash
+   helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml
+   kubectl scale sts zomboid -n games --replicas=1
+   ```
+
+7. Watch logs and confirm world + character load correctly.
+
+Keep the same `serverName` as on Windows. Changing it creates a new world.
+
+## Backups
+
+### CronJob (crash-consistent)
+
+The built-in CronJob reads live files from the data PVC without coordinating a save with the running server. **Backups are crash-consistent, not application-consistent.** Files copied while the server is mid-write may be incomplete.
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 4 * * *"
+  retentionDays: 7
+```
+
+Archives are written to the `backups` PVC at `/backups/<serverName>-YYYYMMDD-HHMMSS.tar.gz`.
+
+Trigger a manual run immediately after an RCON save:
+```bash
+kubectl create job \
+  --from=cronjob/zomboid-backup \
+  zomboid-backup-manual-$(date +%s) \
+  -n games
+```
+
+### CSI VolumeSnapshots
+
+A CSI snapshot taken without a prior RCON save is still crash-consistent. For improved consistency, issue `save` through the RCON console first and wait for confirmation — then take the snapshot immediately:
+
+```bash
+# After confirmed RCON save:
+helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml \
+  --set volumeSnapshot.enabled=true
+helm upgrade zomboid janip81/zomboid-server -n games -f values.yaml \
+  --set volumeSnapshot.enabled=false
+```
+
+For the safest pre-maintenance snapshot:
+1. Issue `save` via RCON console.
+2. Issue `quit` via RCON console.
+3. Confirm the server has stopped (logs show exit).
+4. Take the VolumeSnapshot.
+5. Restart or delete/recreate the pod.
+
+Take snapshots before:
+- Server version upgrade
+- Branch switch (B41 ↔ B42)
+- Large mod list changes
+- World migration from another host
+- Panel upgrades
+
+## First-Deployment Shutdown Test
+
+Before committing a world to production, verify shutdown behavior with this test (use a disposable test world):
+
+1. Start the server and enter the game.
+2. Place or move a recognizable object.
+3. Send `save` through the panel RCON console:
+   ```bash
+   kubectl logs -n games zomboid-0 -c server --tail=100 -f
+   ```
+   Wait until logs confirm the save completed.
+4. Send `quit` through the RCON console.
+5. Confirm a clean exit in the logs.
+6. Delete/recreate the pod:
+   ```bash
+   kubectl delete pod -n games zomboid-0
+   ```
+7. Re-enter the game and verify the object placement survived.
+
+**Separately** (on a disposable world only), test a plain pod deletion without a prior RCON quit:
+```bash
+kubectl delete pod -n games zomboid-0
+```
+Check whether the last auto-save survived. Do **not** rely on this for production worlds until the behavior is confirmed repeatable. Do not update chart documentation to claim graceful SIGTERM handling unless this test passes consistently.
+
+## Cilium LoadBalancer Configuration
+
+```yaml
+service:
+  game:
+    type: LoadBalancer
+    loadBalancerIP: "192.168.101.50"
+    externalTrafficPolicy: Local
+    ports:
+      game: 16261
+      direct: 16262
+    steamPorts:
+      enabled: false   # enable for Steam client discovery (ports 8766, 8767 UDP)
+```
+
+`externalTrafficPolicy: Local` is recommended for a single-replica StatefulSet.
+
+Steam discovery ports (8766/8767 UDP) are disabled by default. Enable them if players use the Steam server browser rather than direct connect.
+
+## Troubleshooting
+
+### Volume ownership errors
+
+```bash
+kubectl exec -it zomboid-0 -n games -c server -- ls -la /home/steam/Zomboid
+```
+
+All files should be owned `1000:1000`. If not, fix with the migration pod:
+```bash
+kubectl exec -it -n games zomboid-migration -- chown -R 1000:1000 /home/steam/Zomboid
+```
+
+### Workshop downloads failing
+
+Mods install on the **second** server start. If they fail repeatedly:
+- Check logs for Steam auth errors.
+- Add `FORCESTEAMCLIENTSOUPDATE=true` via `zomboid.extraEnv` for one restart.
+- Verify the server node can reach Steam (8766/8767 UDP outbound).
+
+### Panel RCON shows server offline
+
+This is expected. The panel cannot detect the PZ process in the server container namespace. `RCON_SKIP_SERVER_CHECK=true` is set automatically — RCON commands work regardless.
+
+### Missing player after migration
+
+- The `db/` directory must have been copied completely.
+- The `serverName` must match exactly (case-sensitive).
+- Check logs for `LoadPlayerData`.
+
+### Panel data PVC full
+
+```bash
+kubectl exec -it zomboid-0 -n games -c panel -- df -h /app/data
+```
+
+If full from panel-created backups:
+```bash
+kubectl exec -it zomboid-0 -n games -c panel -- \
+  find /app/data/backups -name "*.zip" -mtime +7 -delete
+```
+Then increase `persistence.panelData.size` before re-enabling panel backups.
+
+### Why replicas must remain at 1
+
+PZ saves are single-file-per-world. Two replicas writing to the same PVC would corrupt the save. The chart hardcodes `replicas: 1`.
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/zomboid-server/ci/ct-values.yaml
+++ b/charts/zomboid-server/ci/ct-values.yaml
@@ -1,0 +1,55 @@
+# Chart-testing values — disables external dependencies (LB IP, gateway, CSI snapshots)
+image:
+  tag: "41.78.19-release"
+
+zomboid:
+  serverName: "ct-test"
+  adminPassword: "ci-admin-pass"
+  rconPassword: "ci-rcon-pass"
+  adminPasswordBootstrap:
+    enabled: true
+  # selfManagedMods prevents WORKSHOP_IDS="" from clearing mod config in CI
+  selfManagedMods: true
+
+panel:
+  enabled: true
+  image:
+    repository: ghcr.io/fpsacha/zomboid-panel
+    tag: "v1.0.66"
+  corsOrigins: ""
+  https: false
+  rcon:
+    host: "127.0.0.1"
+    port: 27015
+    skipServerCheck: true
+
+service:
+  game:
+    type: ClusterIP
+    externalTrafficPolicy: Cluster
+    steamPorts:
+      enabled: false
+
+gateway:
+  enabled: false
+
+persistence:
+  data:
+    enabled: false
+  serverFiles:
+    enabled: false
+  panelData:
+    enabled: false
+  panelLogs:
+    enabled: false
+  backups:
+    enabled: false
+
+migration:
+  enabled: false
+
+backup:
+  enabled: false
+
+volumeSnapshot:
+  enabled: false

--- a/charts/zomboid-server/examples/argocd-application.yaml
+++ b/charts/zomboid-server/examples/argocd-application.yaml
@@ -1,0 +1,135 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zomboid-server
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    repoURL: https://janip81.github.io/helm-charts/
+    chart: zomboid-server
+    targetRevision: 0.1.0
+    helm:
+      releaseName: zomboid
+      valuesObject:
+        image:
+          repository: danixu86/project-zomboid-dedicated-server
+          # Build 41 stable. Switch to 42.x.x-unstable for Build 42 early access.
+          tag: "41.78.19-release"
+
+        zomboid:
+          serverName: "my-server"
+          adminUsername: "admin"
+          # Reference a pre-existing Secret — do NOT put passwords in Git
+          existingSecret: "zomboid-secrets"
+          secretKeys:
+            adminPassword: "admin-password"
+            rconPassword: "rcon-password"
+            serverPassword: "server-password"
+          # Set false after admin account is created on first run
+          adminPasswordBootstrap:
+            enabled: true
+          public: false
+          maxPlayers: 16
+          minMemory: "3072m"
+          maxMemory: "6144m"
+          serverPreset: "Survival"
+          selfManagedMods: false
+          mods:
+            workshopIds: []
+            modIds: []
+
+        panel:
+          enabled: true
+          image:
+            repository: ghcr.io/fpsacha/zomboid-panel
+            tag: "v1.0.66"
+          port: 3001
+          # Set to the panel hostname when behind Gateway / reverse proxy
+          corsOrigins: "https://zomboid.example.com"
+          https: true
+          rcon:
+            host: "127.0.0.1"
+            port: 27015
+            skipServerCheck: true
+          serverFilesReadOnly: true
+          panelBridge:
+            enabled: false
+
+        service:
+          game:
+            type: LoadBalancer
+            loadBalancerIP: "192.168.101.50"
+            externalTrafficPolicy: Local
+            ports:
+              game: 16261
+              direct: 16262
+            steamPorts:
+              enabled: false
+          panel:
+            type: ClusterIP
+            port: 3001
+
+        gateway:
+          enabled: true
+          parentRefs:
+            - name: main-gateway
+              namespace: gateway
+          hostname: "zomboid.example.com"
+
+        persistence:
+          storageClass: ""
+          data:
+            enabled: true
+            size: 20Gi
+          serverFiles:
+            enabled: true
+            size: 30Gi
+          panelData:
+            enabled: true
+            size: 2Gi
+          panelLogs:
+            enabled: false
+          backups:
+            enabled: true
+            size: 30Gi
+
+        podSecurityContext:
+          fsGroup: 1000
+
+        resources:
+          server:
+            requests:
+              cpu: "1000m"
+              memory: 4Gi
+            limits:
+              cpu: "4000m"
+              memory: 8Gi
+          panel:
+            requests:
+              cpu: "100m"
+              memory: 256Mi
+            limits:
+              cpu: "500m"
+              memory: 512Mi
+
+        terminationGracePeriodSeconds: 90
+
+        backup:
+          enabled: true
+          schedule: "0 4 * * *"
+          retentionDays: 7
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: games
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/charts/zomboid-server/examples/values-prod.yaml
+++ b/charts/zomboid-server/examples/values-prod.yaml
@@ -1,0 +1,185 @@
+# Production values example for zomboid-server
+# Namespace: games (prod-k8s)
+#
+# Required pre-existing Secret (create before deploying):
+#   kubectl create secret generic zomboid-secrets -n games \
+#     --from-literal=admin-password='<strong-password>' \
+#     --from-literal=rcon-password='<strong-rcon-password>' \
+#     --from-literal=server-password=''
+#
+# After first deployment, once the admin account is created:
+#   Set zomboid.adminPasswordBootstrap.enabled: false and upgrade + delete pod.
+
+image:
+  repository: danixu86/project-zomboid-dedicated-server
+  # Build 41 stable. Switch to 42.x.x-unstable for Build 42 early access.
+  tag: "41.78.19-release"
+  pullPolicy: IfNotPresent
+
+zomboid:
+  serverName: "my-server"
+  adminUsername: "admin"
+
+  # Use a pre-existing Secret — never put passwords in Git
+  existingSecret: "zomboid-secrets"
+  secretKeys:
+    adminPassword: "admin-password"
+    rconPassword: "rcon-password"
+    serverPassword: "server-password"
+
+  adminPasswordBootstrap:
+    enabled: true   # set false after first successful startup
+
+  public: false
+  displayName: "My Zomboid Server"
+  maxPlayers: 16
+
+  minMemory: "3072m"
+  maxMemory: "6144m"
+
+  serverPreset: "Survival"
+  serverPresetReplace: false
+
+  selfManagedMods: false
+
+  mods:
+    workshopIds: []
+    modIds: []
+    modFolders: "workshop,steam,mods"
+
+panel:
+  enabled: true
+  image:
+    repository: ghcr.io/fpsacha/zomboid-panel
+    tag: "v1.0.66"
+    pullPolicy: IfNotPresent
+  port: 3001
+  corsOrigins: "https://zomboid.example.com"
+  https: true
+  rcon:
+    host: "127.0.0.1"
+    port: 27015
+    skipServerCheck: true
+  logLevel: "info"
+  steamApiKey: ""
+  serverFilesReadOnly: true
+  panelBridge:
+    enabled: false
+
+service:
+  game:
+    type: LoadBalancer
+    loadBalancerIP: "192.168.101.50"
+    externalTrafficPolicy: Local
+    annotations: {}
+    ports:
+      game: 16261
+      direct: 16262
+    steamPorts:
+      enabled: false
+  panel:
+    type: ClusterIP
+    port: 3001
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: main-gateway
+      namespace: gateway
+  hostname: "zomboid.example.com"
+
+persistence:
+  storageClass: ""
+  data:
+    enabled: true
+    size: 20Gi
+    accessModes:
+      - ReadWriteOnce
+  serverFiles:
+    enabled: true
+    size: 30Gi
+    accessModes:
+      - ReadWriteOnce
+  panelData:
+    enabled: true
+    size: 2Gi
+    accessModes:
+      - ReadWriteOnce
+  panelLogs:
+    enabled: false
+  backups:
+    enabled: true
+    size: 30Gi
+    accessModes:
+      - ReadWriteOnce
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  # Server container runs as root initially (entrypoint chowns PVCs then su - steam).
+  # Do not set runAsUser/runAsNonRoot/capabilities.drop here without testing.
+  server: {}
+  panel:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+resources:
+  server:
+    requests:
+      cpu: "1000m"
+      memory: 4Gi
+    limits:
+      cpu: "4000m"
+      memory: 8Gi
+  panel:
+    requests:
+      cpu: "100m"
+      memory: 256Mi
+    limits:
+      cpu: "500m"
+      memory: 512Mi
+
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 60
+  periodSeconds: 15
+  failureThreshold: 40
+  timeoutSeconds: 5
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 15
+  failureThreshold: 10
+  timeoutSeconds: 5
+
+livenessProbe:
+  enabled: false
+
+terminationGracePeriodSeconds: 90
+
+backup:
+  enabled: true
+  schedule: "0 4 * * *"
+  retentionDays: 7
+  image:
+    repository: alpine
+    tag: "3.19"
+    pullPolicy: IfNotPresent
+
+volumeSnapshot:
+  enabled: false
+  snapshotClassName: ""
+  data:
+    enabled: true
+  serverFiles:
+    enabled: true
+
+migration:
+  enabled: false

--- a/charts/zomboid-server/templates/NOTES.txt
+++ b/charts/zomboid-server/templates/NOTES.txt
@@ -1,0 +1,96 @@
+== Project Zomboid Dedicated Server ==
+
+StatefulSet: {{ include "zomboid-server.fullname" . }}
+Namespace:   {{ .Release.Namespace }}
+Image:       {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+
+== Game Traffic ==
+
+{{- if eq .Values.service.game.type "LoadBalancer" }}
+The game service is type LoadBalancer. Once an external IP is assigned:
+
+  kubectl get svc {{ include "zomboid-server.fullname" . }}-game -n {{ .Release.Namespace }}
+
+Players connect to:  <EXTERNAL-IP>:{{ .Values.service.game.ports.game }} (UDP)
+Direct connect port: <EXTERNAL-IP>:{{ .Values.service.game.ports.direct }} (UDP)
+{{- if .Values.service.game.steamPorts.enabled }}
+Steam ports exposed: {{ .Values.service.game.steamPorts.port1 }}/UDP, {{ .Values.service.game.steamPorts.port2 }}/UDP
+{{- else }}
+Steam ports:  disabled (service.game.steamPorts.enabled=false)
+{{- end }}
+{{- else }}
+Game service type: {{ .Values.service.game.type }}
+Game port:   {{ .Values.service.game.ports.game }}/UDP
+Direct port: {{ .Values.service.game.ports.direct }}/UDP
+{{- end }}
+
+== Web Panel ==
+
+{{- if .Values.panel.enabled }}
+Panel image: {{ .Values.panel.image.repository }}:{{ .Values.panel.image.tag }}
+{{- if .Values.gateway.enabled }}
+Panel URL: https://{{ .Values.gateway.hostname }}
+{{- else }}
+Panel is enabled but no Gateway route is configured.
+Access via port-forward:
+
+  kubectl port-forward -n {{ .Release.Namespace }} sts/{{ include "zomboid-server.fullname" . }} {{ .Values.panel.port }}:{{ .Values.panel.port }}
+
+Then open: http://localhost:{{ .Values.panel.port }}
+{{- end }}
+
+RCON connects internally at 127.0.0.1:{{ .Values.zomboid.rcon.port }} (not a Service).
+{{- else }}
+Panel is disabled (panel.enabled=false).
+{{- end }}
+
+== First-Run Checklist ==
+
+{{- if .Values.zomboid.adminPasswordBootstrap.enabled }}
+1. ADMIN PASSWORD: ADMINPASSWORD is injected from the Secret on this startup.
+   The server passes it as a command-line argument — it will appear in logs.
+   After the admin account is created, set:
+     zomboid.adminPasswordBootstrap.enabled: false
+   Then upgrade and delete the pod to apply.
+{{- else }}
+1. adminPasswordBootstrap.enabled is false — ADMINPASSWORD is NOT injected.
+   Ensure the admin account was already created on a previous startup.
+{{- end }}
+
+2. Mods install on the SECOND server start; map mods load on the THIRD.
+   Do not be alarmed if the server restarts itself during first setup.
+
+== Applying Upgrades (OnDelete strategy) ==
+
+StatefulSet template changes do NOT automatically restart the pod.
+The pod WILL restart automatically on crash or node failure.
+
+To apply a chart upgrade:
+  kubectl delete pod -n {{ .Release.Namespace }} {{ include "zomboid-server.fullname" . }}-0
+
+The StatefulSet will immediately recreate it with the updated template.
+
+{{- if .Values.migration.enabled }}
+
+== Migration Pod ==
+
+The migration helper pod is ENABLED. Scale down the StatefulSet first:
+  kubectl scale sts {{ include "zomboid-server.fullname" . }} --replicas=0 -n {{ .Release.Namespace }}
+
+Copy files:
+  kubectl cp <source> {{ .Release.Namespace }}/{{ include "zomboid-server.fullname" . }}-migration:<dest>
+
+Set migration.enabled: false and run helm upgrade to remove the pod when done.
+{{- end }}
+
+{{- if .Values.backup.enabled }}
+
+== Backup CronJob (crash-consistent) ==
+
+Schedule: {{ .Values.backup.schedule }}
+Archives: /backups/<serverName>-YYYYMMDD-HHMMSS.tar.gz
+Retention: {{ .Values.backup.retentionDays }} days
+
+WARNING: backups are crash-consistent (live files, no server coordination).
+For application-consistent backups, use VolumeSnapshot or panel backups.
+{{- end }}

--- a/charts/zomboid-server/templates/_helpers.tpl
+++ b/charts/zomboid-server/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "zomboid-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "zomboid-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "zomboid-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "zomboid-server.labels" -}}
+helm.sh/chart: {{ include "zomboid-server.chart" . }}
+{{ include "zomboid-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "zomboid-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "zomboid-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Name of the secret containing passwords.
+Returns the existingSecret name if set, otherwise the chart-created secret name.
+*/}}
+{{- define "zomboid-server.secretName" -}}
+{{- if .Values.zomboid.existingSecret }}
+{{- .Values.zomboid.existingSecret }}
+{{- else }}
+{{- include "zomboid-server.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the effective StorageClass for a given persistence section.
+Uses the per-PVC storageClass if set, otherwise falls back to persistence.storageClass.
+*/}}
+{{- define "zomboid-server.storageClass" -}}
+{{- $sc := .local.storageClass | default .global -}}
+{{- if $sc -}}
+{{- if eq $sc "-" -}}
+storageClassName: ""
+{{- else -}}
+storageClassName: {{ $sc | quote }}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/zomboid-server/templates/backup-cronjob.yaml
+++ b/charts/zomboid-server/templates/backup-cronjob.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.backup.enabled }}
+# CRASH-CONSISTENT BACKUP — NOT APPLICATION-CONSISTENT
+#
+# This CronJob archives world saves and player DB from a live running server
+# without coordinating a save with the game process first.
+# Files copied while the server is running may be in an inconsistent state.
+#
+# For stronger consistency guarantees, use one of these approaches instead:
+#   1. VolumeSnapshot (preferred): trigger an RCON save, then take a CSI snapshot.
+#   2. Panel backups: the Zomboid Control Panel has a built-in backup scheduler
+#      that can coordinate saves before archiving.
+#   3. Graceful stop: scale the StatefulSet to 0, archive, then restart.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-backup
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+  annotations:
+    zomboid.io/backup-consistency: "crash-consistent"
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "zomboid-server.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            fsGroup: 1000
+          containers:
+            - name: backup
+              image: "{{ .Values.backup.image.repository }}:{{ .Values.backup.image.tag }}"
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+              securityContext:
+                runAsUser: 1000
+                runAsGroup: 1000
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              env:
+                - name: RETENTION_DAYS
+                  value: {{ .Values.backup.retentionDays | quote }}
+                - name: SERVER_NAME
+                  value: {{ .Values.zomboid.serverName | quote }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+                  ARCHIVE="/backups/${SERVER_NAME}-${TIMESTAMP}.tar.gz"
+
+                  echo "[backup] CRASH-CONSISTENT: archiving live server data for ${SERVER_NAME} at ${TIMESTAMP}"
+                  echo "[backup] Files may be in-flight. For application-consistent backups use a VolumeSnapshot."
+
+                  # Archive saves, server config, and player DB.
+                  # Kubernetes Secrets are never included in the archive.
+                  tar -czf "${ARCHIVE}" \
+                    -C /home/steam/Zomboid \
+                    --ignore-failed-read \
+                    "Saves/Multiplayer/${SERVER_NAME}" \
+                    "Server/${SERVER_NAME}.ini" \
+                    "Server/${SERVER_NAME}_SandboxVars.lua" \
+                    "db" \
+                    2>/dev/null || true
+
+                  echo "[backup] Written: ${ARCHIVE} ($(du -sh "${ARCHIVE}" | cut -f1))"
+
+                  # Prune archives older than RETENTION_DAYS
+                  find /backups -name "${SERVER_NAME}-*.tar.gz" -mtime +${RETENTION_DAYS} -delete
+                  echo "[backup] Pruned backups older than ${RETENTION_DAYS} days"
+              volumeMounts:
+                - name: data
+                  mountPath: /home/steam/Zomboid
+                  readOnly: true
+                - name: backups
+                  mountPath: /backups
+          volumes:
+            - name: data
+              {{- if .Values.persistence.data.existingClaim }}
+              persistentVolumeClaim:
+                claimName: {{ .Values.persistence.data.existingClaim }}
+              {{- else }}
+              persistentVolumeClaim:
+                claimName: {{ include "zomboid-server.fullname" . }}-data
+              {{- end }}
+            - name: backups
+              {{- if .Values.persistence.backups.existingClaim }}
+              persistentVolumeClaim:
+                claimName: {{ .Values.persistence.backups.existingClaim }}
+              {{- else }}
+              persistentVolumeClaim:
+                claimName: {{ include "zomboid-server.fullname" . }}-backups
+              {{- end }}
+{{- end }}

--- a/charts/zomboid-server/templates/httproute.yaml
+++ b/charts/zomboid-server/templates/httproute.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.panel.enabled .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-panel
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - {{ .Values.gateway.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "zomboid-server.fullname" . }}-panel
+          port: {{ .Values.service.panel.port }}
+{{- end }}

--- a/charts/zomboid-server/templates/migration-pod.yaml
+++ b/charts/zomboid-server/templates/migration-pod.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.migration.enabled }}
+# Migration helper pod — mounts all PVCs and sleeps so you can kubectl cp save files.
+# Scale the StatefulSet to 0 before enabling this pod, then copy files, then disable it.
+# See README.md for the full migration procedure.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-migration
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migration
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  # Migration pod must never run at the same time as the StatefulSet pod.
+  # Scale the StatefulSet to 0 (kubectl scale sts ... --replicas=0) before enabling this.
+  restartPolicy: Never
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: migration
+      image: "{{ .Values.migration.image.repository }}:{{ .Values.migration.image.tag }}"
+      imagePullPolicy: {{ .Values.migration.image.pullPolicy }}
+      command: ["/bin/sh", "-c", "echo 'Migration pod ready. Use kubectl cp to transfer files.'; sleep infinity"]
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+      volumeMounts:
+        - name: data
+          mountPath: /home/steam/Zomboid
+        - name: server-files
+          mountPath: /home/steam/pz-dedicated/steamapps/workshop
+        - name: backups
+          mountPath: /backups
+  volumes:
+    - name: data
+      {{- if .Values.persistence.data.existingClaim }}
+      persistentVolumeClaim:
+        claimName: {{ .Values.persistence.data.existingClaim }}
+      {{- else }}
+      persistentVolumeClaim:
+        claimName: {{ include "zomboid-server.fullname" . }}-data
+      {{- end }}
+    - name: server-files
+      {{- if .Values.persistence.serverFiles.existingClaim }}
+      persistentVolumeClaim:
+        claimName: {{ .Values.persistence.serverFiles.existingClaim }}
+      {{- else }}
+      persistentVolumeClaim:
+        claimName: {{ include "zomboid-server.fullname" . }}-server-files
+      {{- end }}
+    - name: backups
+      {{- if .Values.persistence.backups.existingClaim }}
+      persistentVolumeClaim:
+        claimName: {{ .Values.persistence.backups.existingClaim }}
+      {{- else }}
+      persistentVolumeClaim:
+        claimName: {{ include "zomboid-server.fullname" . }}-backups
+      {{- end }}
+{{- end }}

--- a/charts/zomboid-server/templates/pvc.yaml
+++ b/charts/zomboid-server/templates/pvc.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-data
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.data.accessModes | nindent 4 }}
+  {{- include "zomboid-server.storageClass" (dict "local" .Values.persistence.data "global" .Values.persistence.storageClass) | nindent 2 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size }}
+{{- end }}
+
+{{- if and .Values.persistence.serverFiles.enabled (not .Values.persistence.serverFiles.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-server-files
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.serverFiles.accessModes | nindent 4 }}
+  {{- include "zomboid-server.storageClass" (dict "local" .Values.persistence.serverFiles "global" .Values.persistence.storageClass) | nindent 2 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.serverFiles.size }}
+{{- end }}
+
+{{- if and .Values.persistence.panelData.enabled (not .Values.persistence.panelData.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-panel-data
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.panelData.accessModes | nindent 4 }}
+  {{- include "zomboid-server.storageClass" (dict "local" .Values.persistence.panelData "global" .Values.persistence.storageClass) | nindent 2 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.panelData.size }}
+{{- end }}
+
+{{- if and .Values.persistence.panelLogs.enabled (not .Values.persistence.panelLogs.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-panel-logs
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.panelLogs.accessModes | nindent 4 }}
+  {{- include "zomboid-server.storageClass" (dict "local" .Values.persistence.panelLogs "global" .Values.persistence.storageClass) | nindent 2 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.panelLogs.size }}
+{{- end }}
+
+{{- if and .Values.persistence.backups.enabled (not .Values.persistence.backups.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-backups
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.backups.accessModes | nindent 4 }}
+  {{- include "zomboid-server.storageClass" (dict "local" .Values.persistence.backups "global" .Values.persistence.storageClass) | nindent 2 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.backups.size }}
+{{- end }}

--- a/charts/zomboid-server/templates/secret.yaml
+++ b/charts/zomboid-server/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.zomboid.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.zomboid.secretKeys.adminPassword }}: {{ .Values.zomboid.adminPassword | toString | b64enc | quote }}
+  {{ .Values.zomboid.secretKeys.rconPassword }}: {{ .Values.zomboid.rconPassword | toString | b64enc | quote }}
+  {{ .Values.zomboid.secretKeys.serverPassword }}: {{ .Values.zomboid.serverPassword | toString | b64enc | quote }}
+{{- end }}

--- a/charts/zomboid-server/templates/service-game.yaml
+++ b/charts/zomboid-server/templates/service-game.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-game
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+  {{- with .Values.service.game.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.game.type }}
+  {{- if and (eq .Values.service.game.type "LoadBalancer") .Values.service.game.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.game.loadBalancerIP }}
+  {{- end }}
+  {{- if eq .Values.service.game.type "LoadBalancer" }}
+  externalTrafficPolicy: {{ .Values.service.game.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - name: game
+      port: {{ .Values.service.game.ports.game }}
+      targetPort: game
+      protocol: UDP
+    - name: direct
+      port: {{ .Values.service.game.ports.direct }}
+      targetPort: direct
+      protocol: UDP
+    {{- if .Values.service.game.steamPorts.enabled }}
+    - name: steam1
+      port: {{ .Values.service.game.steamPorts.port1 }}
+      targetPort: steam1
+      protocol: UDP
+    - name: steam2
+      port: {{ .Values.service.game.steamPorts.port2 }}
+      targetPort: steam2
+      protocol: UDP
+    {{- end }}
+  selector:
+    {{- include "zomboid-server.selectorLabels" . | nindent 4 }}

--- a/charts/zomboid-server/templates/service-panel.yaml
+++ b/charts/zomboid-server/templates/service-panel.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.panel.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-panel
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.panel.type }}
+  ports:
+    - name: panel-http
+      port: {{ .Values.service.panel.port }}
+      targetPort: panel-http
+      protocol: TCP
+  selector:
+    {{- include "zomboid-server.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/zomboid-server/templates/statefulset.yaml
+++ b/charts/zomboid-server/templates/statefulset.yaml
@@ -1,0 +1,329 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "zomboid-server.selectorLabels" . | nindent 6 }}
+  # OnDelete: StatefulSet template changes do NOT automatically replace the running pod.
+  # The pod WILL be automatically recreated by Kubernetes on crash, node loss, or eviction.
+  # To apply a chart upgrade, delete the pod manually:
+  #   kubectl delete pod -n <namespace> <release-name>-0
+  # The StatefulSet will then immediately recreate it using the updated template.
+  updateStrategy:
+    type: OnDelete
+  template:
+    metadata:
+      labels:
+        {{- include "zomboid-server.selectorLabels" . | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        # ── Game server ──────────────────────────────────────────────────────────
+        - name: server
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext.server | nindent 12 }}
+          env:
+            - name: SERVERNAME
+              value: {{ .Values.zomboid.serverName | quote }}
+            - name: ADMINUSERNAME
+              value: {{ .Values.zomboid.adminUsername | quote }}
+            {{- if .Values.zomboid.adminPasswordBootstrap.enabled }}
+            # ADMINPASSWORD is required for first-run account creation.
+            # The image passes it as a command-line argument; it will appear in server logs.
+            # After the admin account is created, set adminPasswordBootstrap.enabled: false.
+            - name: ADMINPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zomboid-server.secretName" . }}
+                  key: {{ .Values.zomboid.secretKeys.adminPassword }}
+            {{- end }}
+            - name: RCONPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zomboid-server.secretName" . }}
+                  key: {{ .Values.zomboid.secretKeys.rconPassword }}
+            {{- if .Values.zomboid.serverPassword }}
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zomboid-server.secretName" . }}
+                  key: {{ .Values.zomboid.secretKeys.serverPassword }}
+            {{- end }}
+            - name: PUBLIC
+              value: {{ .Values.zomboid.public | quote }}
+            {{- if .Values.zomboid.displayName }}
+            - name: DISPLAYNAME
+              value: {{ .Values.zomboid.displayName | quote }}
+            {{- end }}
+            - name: MIN_MEMORY
+              value: {{ .Values.zomboid.minMemory | quote }}
+            - name: MAX_MEMORY
+              value: {{ .Values.zomboid.maxMemory | quote }}
+            - name: SERVERPRESET
+              value: {{ .Values.zomboid.serverPreset | quote }}
+            - name: SERVERPRESETREPLACE
+              value: {{ .Values.zomboid.serverPresetReplace | quote }}
+            - name: PORT
+              value: {{ .Values.service.game.ports.game | quote }}
+            - name: UDPPORT
+              value: {{ .Values.service.game.ports.direct | quote }}
+            {{- if .Values.service.game.steamPorts.enabled }}
+            - name: STEAMPORT1
+              value: {{ .Values.service.game.steamPorts.port1 | quote }}
+            - name: STEAMPORT2
+              value: {{ .Values.service.game.steamPorts.port2 | quote }}
+            {{- end }}
+            - name: MODFOLDERS
+              value: {{ .Values.zomboid.mods.modFolders | quote }}
+            {{- if .Values.zomboid.noSteam }}
+            - name: NOSTEAM
+              value: "true"
+            {{- end }}
+            {{- if or .Values.zomboid.selfManagedMods (and (empty .Values.zomboid.mods.workshopIds) (empty .Values.zomboid.mods.modIds)) }}
+            # Protect existing INI mod config when no mods are specified in values,
+            # or when selfManagedMods is explicitly enabled.
+            - name: SELF_MANAGED_MODS
+              value: "true"
+            {{- else }}
+            - name: WORKSHOP_IDS
+              value: {{ join ";" .Values.zomboid.mods.workshopIds | quote }}
+            - name: MOD_IDS
+              value: {{ join ";" .Values.zomboid.mods.modIds | quote }}
+            {{- end }}
+            # CACHEDIR controls where the server writes all persistent data.
+            # Must match the mountPath of the data volume below.
+            - name: CACHEDIR
+              value: /home/steam/Zomboid
+            {{- with .Values.zomboid.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: game
+              containerPort: {{ .Values.service.game.ports.game }}
+              protocol: UDP
+            - name: direct
+              containerPort: {{ .Values.service.game.ports.direct }}
+              protocol: UDP
+            {{- if .Values.service.game.steamPorts.enabled }}
+            - name: steam1
+              containerPort: {{ .Values.service.game.steamPorts.port1 }}
+              protocol: UDP
+            - name: steam2
+              containerPort: {{ .Values.service.game.steamPorts.port2 }}
+              protocol: UDP
+            {{- end }}
+            # RCON is never exposed as a Service — panel connects via 127.0.0.1 within the pod
+            - name: rcon
+              containerPort: {{ .Values.zomboid.rcon.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /home/steam/Zomboid
+            - name: server-files
+              mountPath: /home/steam/pz-dedicated
+            - name: backups
+              mountPath: /backups
+          resources:
+            {{- toYaml .Values.resources.server | nindent 12 }}
+          # Startup probe — generous budget for first-start Steam and Workshop downloads
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            exec:
+              command:
+                - pgrep
+                - -f
+                - ProjectZomboid
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - pgrep
+                - -f
+                - ProjectZomboid
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - -f
+                - ProjectZomboid
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          {{- end }}
+
+        {{- if .Values.panel.enabled }}
+        # ── Zomboid Control Panel ────────────────────────────────────────────────
+        # ghcr.io/fpsacha/zomboid-panel — https://github.com/fpsacha/zomboid-control-panel
+        # No Docker socket. No privileged mode. Connects to PZ via RCON + shared volumes.
+        - name: panel
+          image: "{{ .Values.panel.image.repository }}:{{ .Values.panel.image.tag }}"
+          imagePullPolicy: {{ .Values.panel.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext.panel | nindent 12 }}
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: {{ .Values.panel.port | quote }}
+            - name: PZ_SERVER_PATH
+              value: "/pz-server"
+            - name: PZ_SAVE_PATH
+              value: "/zomboid"
+            - name: PZ_SERVER_BAT
+              value: "start-server.sh"
+            # RCON — connects to the game server at localhost within the shared pod network namespace.
+            # RCON is never exposed as a Kubernetes Service (containerPort rcon is internal only).
+            - name: RCON_HOST
+              value: {{ .Values.panel.rcon.host | quote }}
+            - name: RCON_PORT
+              value: {{ .Values.panel.rcon.port | quote }}
+            - name: RCON_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zomboid-server.secretName" . }}
+                  key: {{ .Values.zomboid.secretKeys.rconPassword }}
+            # The panel sidecar cannot inspect the PZ server process (separate container
+            # namespace). Without skipServerCheck=true the panel would refuse RCON commands
+            # because it can never detect the process as running. RCON still works fine.
+            - name: RCON_SKIP_SERVER_CHECK
+              value: {{ .Values.panel.rcon.skipServerCheck | quote }}
+            - name: HTTPS
+              value: {{ .Values.panel.https | quote }}
+            {{- if .Values.panel.corsOrigins }}
+            - name: CORS_ORIGINS
+              value: {{ .Values.panel.corsOrigins | quote }}
+            {{- end }}
+            - name: LOG_LEVEL
+              value: {{ .Values.panel.logLevel | quote }}
+            {{- if .Values.panel.steamApiKey }}
+            - name: STEAM_API_KEY
+              value: {{ .Values.panel.steamApiKey | quote }}
+            {{- end }}
+            {{- with .Values.panel.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: panel-http
+              containerPort: {{ .Values.panel.port }}
+              protocol: TCP
+          volumeMounts:
+            # Panel state — DB, JWT secret, panel configuration
+            - name: panel-data
+              mountPath: /app/data
+            # Panel logs
+            - name: panel-logs
+              mountPath: /app/logs
+            # PZ server install (same PVC as server's /home/steam/pz-dedicated)
+            # Read-only by default. Set panel.serverFilesReadOnly: false for PanelBridge.
+            - name: server-files
+              mountPath: /pz-server
+              readOnly: {{ .Values.panel.serverFilesReadOnly }}
+            # PZ user data (same PVC as server's /home/steam/Zomboid)
+            # Must be writable for PanelBridge IPC (writes JSON under Lua/panelbridge/).
+            - name: data
+              mountPath: /zomboid
+          resources:
+            {{- toYaml .Values.resources.panel | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: panel-http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: panel-http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+            timeoutSeconds: 5
+        {{- end }}
+
+      volumes:
+        - name: data
+          {{- if and .Values.persistence.data.enabled .Values.persistence.data.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.data.existingClaim }}
+          {{- else if .Values.persistence.data.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "zomboid-server.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: server-files
+          {{- if and .Values.persistence.serverFiles.enabled .Values.persistence.serverFiles.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.serverFiles.existingClaim }}
+          {{- else if .Values.persistence.serverFiles.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "zomboid-server.fullname" . }}-server-files
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: panel-data
+          {{- if and .Values.persistence.panelData.enabled .Values.persistence.panelData.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.panelData.existingClaim }}
+          {{- else if .Values.persistence.panelData.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "zomboid-server.fullname" . }}-panel-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: panel-logs
+          {{- if and .Values.persistence.panelLogs.enabled .Values.persistence.panelLogs.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.panelLogs.existingClaim }}
+          {{- else if .Values.persistence.panelLogs.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "zomboid-server.fullname" . }}-panel-logs
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: backups
+          {{- if and .Values.persistence.backups.enabled .Values.persistence.backups.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.backups.existingClaim }}
+          {{- else if .Values.persistence.backups.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "zomboid-server.fullname" . }}-backups
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/zomboid-server/templates/volumesnapshot.yaml
+++ b/charts/zomboid-server/templates/volumesnapshot.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.volumeSnapshot.enabled }}
+# VolumeSnapshot resources — triggered by setting volumeSnapshot.enabled=true.
+# Take snapshots BEFORE: version upgrades, branch switches (B41↔B42), large mod changes,
+# world migration, and panel upgrades.
+# Requires a CSI driver that supports the VolumeSnapshot API (e.g. vSphere CSI ≥ 3.0).
+{{- if .Values.volumeSnapshot.data.enabled }}
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-data-{{ now | date "20060102-150405" }}
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snapshot
+spec:
+  {{- if .Values.volumeSnapshot.snapshotClassName }}
+  volumeSnapshotClassName: {{ .Values.volumeSnapshot.snapshotClassName }}
+  {{- end }}
+  source:
+    persistentVolumeClaimName: {{ if .Values.persistence.data.existingClaim }}{{ .Values.persistence.data.existingClaim }}{{ else }}{{ include "zomboid-server.fullname" . }}-data{{ end }}
+{{- end }}
+{{- if .Values.volumeSnapshot.serverFiles.enabled }}
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-server-files-{{ now | date "20060102-150405" }}
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snapshot
+spec:
+  {{- if .Values.volumeSnapshot.snapshotClassName }}
+  volumeSnapshotClassName: {{ .Values.volumeSnapshot.snapshotClassName }}
+  {{- end }}
+  source:
+    persistentVolumeClaimName: {{ if .Values.persistence.serverFiles.existingClaim }}{{ .Values.persistence.serverFiles.existingClaim }}{{ else }}{{ include "zomboid-server.fullname" . }}-server-files{{ end }}
+{{- end }}
+{{- end }}

--- a/charts/zomboid-server/values.yaml
+++ b/charts/zomboid-server/values.yaml
@@ -1,0 +1,472 @@
+# -- Docker image for the Project Zomboid dedicated server.
+# Build 41 vs Build 42 is determined by the image tag — STEAMAPPBRANCH is baked at build time.
+# Build 41 (stable):       danixu86/project-zomboid-dedicated-server:41.78.19-release
+# Build 42 (early access): danixu86/project-zomboid-dedicated-server:42.19.0-unstable
+image:
+  # -- Docker repository for the server image
+  repository: danixu86/project-zomboid-dedicated-server
+  # -- Image tag. Pin to a specific version; floating tags are discouraged in production.
+  # @default -- 41.78.19-release (Build 41 stable)
+  tag: "41.78.19-release"
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Provide a name override for chart resources
+nameOverride: ""
+# -- Provide a full name override for chart resources
+fullnameOverride: ""
+
+# Project Zomboid server configuration
+zomboid:
+  # -- Server name identifier (no spaces or special characters — admin login will fail)
+  serverName: "zomboid"
+  # -- Admin username
+  adminUsername: "admin"
+
+  # -- Reference an existing Kubernetes Secret instead of creating one.
+  # The secret must contain the keys defined in secretKeys.
+  # Set to "" to have the chart create a secret from the inline password values below.
+  existingSecret: ""
+
+  # -- Keys within the secret that hold each password
+  secretKeys:
+    # -- Key holding the admin password
+    adminPassword: "admin-password"
+    # -- Key holding the RCON password
+    rconPassword: "rcon-password"
+    # -- Key holding the server join password
+    serverPassword: "server-password"
+
+  # Inline passwords — only used when existingSecret is "" (chart creates the Secret).
+  # -- Admin password (only used for initial account creation; see adminPasswordBootstrap)
+  adminPassword: ""
+  # -- RCON password
+  rconPassword: ""
+  # -- Server join password (leave empty for no password)
+  serverPassword: ""
+
+  # Admin password bootstrap control.
+  # The danixu86 image passes ADMINPASSWORD as a command-line argument to the PZ server,
+  # which logs the full argument list in clear text on every startup.
+  #
+  # On first run, ADMINPASSWORD is required to create the admin account.
+  # After the account is created, set enabled: false to stop injecting the password
+  # into the process environment (and logs).
+  # The RCON password is always injected regardless of this setting.
+  adminPasswordBootstrap:
+    # -- Inject ADMINPASSWORD from the Secret on startup.
+    # Set false after the admin account has been created on first run.
+    enabled: true
+
+  # -- Show server in the in-game server browser
+  public: false
+  # -- Display name in the server browser (kept from INI if left empty)
+  displayName: ""
+  # -- Maximum player slots
+  maxPlayers: 16
+
+  # Java JVM memory settings
+  # -- Minimum JVM heap allocation (e.g. 2048m). Falls back to MEMORY if unset.
+  minMemory: "2048m"
+  # -- Maximum JVM heap allocation (e.g. 4096m). Must be below the container memory limit.
+  maxMemory: "4096m"
+
+  # -- Difficulty preset for a new server
+  # Options: Apocalypse, Beginner, Builder, FirstWeek, SixMonthsLater, Survival, Survivor
+  serverPreset: "Survival"
+  # -- Replace the preset on every container start.
+  # Set true only during initial setup; set false afterwards to protect custom INI edits.
+  serverPresetReplace: false
+
+  # Mod management
+  # -- When true, the entrypoint will NOT modify Mods/WorkshopItems in the server INI.
+  # Use this after initial mod setup or when managing mods via the web panel.
+  # WARNING: when false and workshopIds/modIds are both empty, the entrypoint will
+  # CLEAR existing mod config in the INI file on every restart.
+  selfManagedMods: false
+
+  mods:
+    # -- Steam Workshop item IDs (list of strings, e.g. ["2392709985","2458631365"])
+    workshopIds: []
+    # -- Mod IDs to load (list of strings; prefix each with \\ for Build 42)
+    modIds: []
+    # -- Mod source folders (comma-separated, order matters for load priority)
+    modFolders: "workshop,steam,mods"
+
+  rcon:
+    # -- RCON port (internal only; never exposed outside the pod)
+    port: 27015
+
+  # -- Allow non-Steam clients to connect
+  noSteam: false
+
+  # -- Additional environment variables passed to the server container
+  extraEnv: []
+  # - name: FORCEUPDATE
+  #   value: "true"
+
+# Zomboid Control Panel sidecar
+# Image: ghcr.io/fpsacha/zomboid-panel (https://github.com/fpsacha/zomboid-control-panel)
+# The panel connects to the game server via RCON at 127.0.0.1 and accesses PZ
+# data directories through shared volume mounts. No Docker socket is required.
+panel:
+  # -- Enable the Zomboid Control Panel sidecar
+  enabled: true
+
+  image:
+    # -- Panel image repository
+    repository: ghcr.io/fpsacha/zomboid-panel
+    # -- Panel image tag (pin to a specific release in production)
+    tag: "v1.0.66"
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+
+  # -- Panel HTTP port
+  port: 3001
+
+  # -- CORS allowed origins. Required when the panel is behind a reverse proxy.
+  # Set to the full URL the panel is accessed from, e.g. "https://zomboid.example.com".
+  # Leave empty for LAN/localhost access (private IPs are allowed automatically).
+  corsOrigins: ""
+
+  # -- Set true when the panel is served over HTTPS by a reverse proxy (Gateway API).
+  # Enables HSTS and upgrade-insecure-requests security headers.
+  https: true
+
+  # RCON connection settings for the panel sidecar.
+  # The panel connects to the game server at 127.0.0.1 within the shared pod network namespace.
+  # RCON is never exposed outside the pod as a Kubernetes Service.
+  rcon:
+    # -- Hostname the panel uses to reach the game server RCON
+    host: "127.0.0.1"
+    # -- RCON port the panel connects to (must match zomboid.rcon.port)
+    port: 27015
+    # -- Allow RCON even when the panel cannot detect the PZ process.
+    # Must be true in Kubernetes: the panel sidecar runs in a separate container and
+    # cannot inspect the server container's process list. RCON commands still work.
+    skipServerCheck: true
+
+  # -- Optional Steam Web API key for richer mod metadata from the Workshop.
+  # See https://steamcommunity.com/dev/apikey
+  steamApiKey: ""
+
+  # -- Winston log level for the panel process (error, warn, info, debug)
+  logLevel: "info"
+
+  # PanelBridge is a server-side Lua mod that enables features beyond RCON (teleport,
+  # heal, weather, character export). PanelBridge is DISABLED BY DEFAULT.
+  # Enabling it requires:
+  #   1. DoLuaChecksum=false in the server INI (set via zomboid.extraEnv)
+  #   2. panel.serverFilesReadOnly: false (panel must write PanelBridge.lua to /pz-server)
+  #   3. A server restart after enabling
+  # See README for details.
+  panelBridge:
+    # -- Enable PanelBridge integration (requires DoLuaChecksum=false and write access to /pz-server)
+    enabled: false
+
+  # -- Mount the PZ server install (/pz-server) as read-only in the panel container.
+  # Must be set to false when panelBridge.enabled is true, because PanelBridge
+  # needs to write PanelBridge.lua into /pz-server/Install/media/lua/server/.
+  serverFilesReadOnly: true
+
+  # -- Extra environment variables for the panel container
+  extraEnv: []
+
+# Services
+service:
+  game:
+    # -- Game service type. LoadBalancer is required for direct UDP game traffic.
+    type: LoadBalancer
+    # -- Static IP from your Cilium LB pool (leave empty for automatic assignment)
+    loadBalancerIP: ""
+    # -- externalTrafficPolicy for the game service.
+    # Local preserves client source IPs and avoids the double-NAT hop.
+    # Correct for a single-replica StatefulSet (traffic only goes to the one pod).
+    externalTrafficPolicy: Local
+    # -- Annotations for the game service (e.g. Cilium LB pool selector)
+    annotations: {}
+    # -- Required game ports (always exposed)
+    ports:
+      # -- Main game UDP port
+      game: 16261
+      # -- Direct-connect UDP port
+      direct: 16262
+    # Steam connectivity ports (8766 and 8767 UDP).
+    # Required for Steam client discovery; not required for direct-connect or NoSteam servers.
+    steamPorts:
+      # -- Enable Steam discovery ports in the game Service
+      enabled: false
+      # -- Steam port 1
+      port1: 8766
+      # -- Steam port 2
+      port2: 8767
+
+  panel:
+    # -- Panel service type (ClusterIP; exposed externally only via Gateway API)
+    type: ClusterIP
+    # -- Panel service port
+    port: 3001
+
+# Gateway API — exposes the web panel via an existing Cilium Gateway
+gateway:
+  # -- Enable the HTTPRoute for the panel
+  enabled: false
+  # -- Annotations on the HTTPRoute resource
+  annotations: {}
+  # -- Parent gateway references
+  parentRefs:
+    - name: main-gateway
+      namespace: gateway
+  # -- Hostname the panel should be reachable on
+  hostname: "zomboid.example.com"
+
+# Persistent storage
+persistence:
+  # -- Default StorageClass for all PVCs (overridable per PVC). Leave "" for cluster default.
+  storageClass: ""
+
+  # Game data PVC
+  # Server mount:  /home/steam/Zomboid  (saves, config, player DB, logs, PanelBridge IPC)
+  # Panel mount:   /zomboid             (writable; PanelBridge IPC writes here)
+  data:
+    # -- Enable the game data PVC
+    enabled: true
+    # -- Use an existing PVC instead of creating one
+    existingClaim: ""
+    # -- Size of the game data PVC
+    size: 20Gi
+    # -- Access modes
+    accessModes:
+      - ReadWriteOnce
+    # -- Per-PVC StorageClass override
+    storageClass: ""
+
+  # Server files PVC
+  # Server mount:  /home/steam/pz-dedicated  (full PZ server install + workshop downloads)
+  # Panel mount:   /pz-server               (read-only by default; writable for PanelBridge)
+  serverFiles:
+    # -- Enable the server files PVC
+    enabled: true
+    # -- Use an existing PVC instead of creating one
+    existingClaim: ""
+    # -- Size of the server files PVC (PZ server binary ~2 GB + workshop mods can be large)
+    size: 30Gi
+    # -- Access modes
+    accessModes:
+      - ReadWriteOnce
+    # -- Per-PVC StorageClass override
+    storageClass: ""
+
+  # Panel data PVC — mounts at /app/data in the panel container
+  # Contains: panel database, JWT secret, panel configuration, and panel-created backups.
+  #
+  # WARNING — PANEL BACKUP STORAGE:
+  # The panel stores all backups created through its UI inside /app/data.
+  # With the default 2Gi PVC, frequent large world backups via the panel WILL fill this PVC.
+  # Risk: once full, the panel process may fail to write its database or configuration.
+  #
+  # Safe options:
+  #   1. Use the chart CronJob or CSI snapshots (recommended — these do not use this PVC).
+  #   2. Increase panelData.size before enabling frequent panel-managed backups.
+  #   3. Trigger a save via the panel RCON console, then run the chart CronJob or a snapshot.
+  #
+  # The backups PVC (mounted at /backups in the server container) is used by the chart
+  # CronJob only — the panel does NOT write into /backups.
+  panelData:
+    # -- Enable the panel data PVC
+    enabled: true
+    # -- Use an existing PVC instead of creating one
+    existingClaim: ""
+    # -- Size of the panel data PVC. Increase if you intend to use the panel backup feature frequently.
+    size: 2Gi
+    # -- Access modes
+    accessModes:
+      - ReadWriteOnce
+    # -- Per-PVC StorageClass override
+    storageClass: ""
+
+  # Panel logs PVC — mounts at /app/logs in the panel container
+  # Panel logs are transient and do not need to survive pod restarts in most cases.
+  # Disabled by default: uses emptyDir. Enable for persistent log retention.
+  panelLogs:
+    # -- Enable a PVC for panel logs (disabled = emptyDir)
+    enabled: false
+    # -- Use an existing PVC instead of creating one
+    existingClaim: ""
+    # -- Size of the panel logs PVC
+    size: 2Gi
+    # -- Access modes
+    accessModes:
+      - ReadWriteOnce
+    # -- Per-PVC StorageClass override
+    storageClass: ""
+
+  # Backups PVC — mounts at /backups in the server container and backup CronJob.
+  # Note: the panel does NOT write into this PVC. Panel-created backups go to /app/data.
+  backups:
+    # -- Enable the backups PVC
+    enabled: true
+    # -- Use an existing PVC instead of creating one
+    existingClaim: ""
+    # -- Size of the backups PVC
+    size: 30Gi
+    # -- Access modes
+    accessModes:
+      - ReadWriteOnce
+    # -- Per-PVC StorageClass override
+    storageClass: ""
+
+# -- Pod-level security context
+# fsGroup 1000 matches the steam/node user GID so mounted PVCs are writable by both containers.
+podSecurityContext:
+  fsGroup: 1000
+
+# Container security contexts
+# NOTE: readOnlyRootFilesystem is intentionally NOT set.
+# SteamCMD and the PZ server write to many locations under /home/steam at runtime.
+# The panel (Node.js) also writes temporary files. Enabling readOnlyRootFilesystem
+# without mapping every writable path to an emptyDir would prevent startup.
+securityContext:
+  # -- Security context for the game server container.
+  #
+  # Left empty intentionally. The danixu86 entrypoint requires root at startup:
+  # it runs chown -R 1000:1000 on the mounted PVC directories (requires CAP_CHOWN)
+  # then uses `su - steam` to drop to the steam user before launching the server.
+  #
+  # These entrypoint operations are INCOMPATIBLE with:
+  #   runAsUser: 1000     — entrypoint must start as root
+  #   runAsNonRoot: true  — same reason
+  #   capabilities.drop: [ALL] — removes CAP_CHOWN, breaking the chown step
+  #
+  # Do not set these values unless a real container startup test with the exact
+  # danixu86 image confirms that the entrypoint completes successfully.
+  server: {}
+
+  # -- Security context for the Zomboid Control Panel sidecar
+  # The panel image is built with UID/GID 1000 (matching the compose default build-arg).
+  # Adjust runAsUser if you see permission errors on /app/data or /zomboid.
+  panel:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+# Resource requests and limits
+resources:
+  # -- Resources for the game server container
+  server:
+    requests:
+      cpu: "1000m"
+      memory: 4Gi
+    limits:
+      cpu: "4000m"
+      memory: 8Gi
+  # -- Resources for the Zomboid Control Panel sidecar
+  panel:
+    requests:
+      cpu: "100m"
+      memory: 256Mi
+    limits:
+      cpu: "500m"
+      memory: 512Mi
+
+# Startup probe — generous timeout because Workshop downloads can take many minutes on first start
+startupProbe:
+  # -- Enable startup probe
+  enabled: true
+  # -- Seconds before the first probe fires
+  initialDelaySeconds: 60
+  # -- How often to probe
+  periodSeconds: 15
+  # -- How many consecutive failures before the pod is killed (60s + 40*15s = 10 min total)
+  failureThreshold: 40
+  # -- Probe timeout
+  timeoutSeconds: 5
+
+# Readiness probe
+readinessProbe:
+  # -- Enable readiness probe
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 15
+  failureThreshold: 10
+  timeoutSeconds: 5
+
+# Liveness probe — disabled by default to avoid restart loops during Steam updates or mod downloads
+livenessProbe:
+  # -- Enable liveness probe
+  enabled: false
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  failureThreshold: 6
+  timeoutSeconds: 5
+
+# -- Seconds Kubernetes waits for the pod to shut down cleanly before SIGKILL.
+# The Danixu entrypoint does not install a verified SIGTERM handler that saves the world.
+# A plain pod deletion or scale-to-zero may terminate the server without an explicit save.
+# Before planned maintenance, issue `save` then `quit` via the panel RCON console first.
+terminationGracePeriodSeconds: 90
+
+# Graceful shutdown configuration.
+# A future release may support RCON-based save-and-quit when a verified RCON client
+# is present inside the server container. Until then, administrators must issue
+# `save` and `quit` manually via the panel's RCON console before planned maintenance.
+shutdown:
+  graceful:
+    # -- Enable graceful shutdown (no verified method is currently implemented)
+    enabled: false
+    # -- Shutdown method. Currently only "none" is supported.
+    # "rcon" may be added in a future release once a client binary is verified
+    # to exist inside the danixu86 image and tested end-to-end.
+    method: "none"
+
+# Migration helper — a sleep pod that mounts all PVCs so you can kubectl cp save files
+migration:
+  # -- Enable the migration helper pod
+  enabled: false
+  image:
+    # -- Image used by the migration pod
+    repository: busybox
+    tag: "1.36"
+    pullPolicy: IfNotPresent
+
+# Backup CronJob — crash-consistent file-level backups to the backups PVC.
+# WARNING: This CronJob reads live files without coordinating with the running game server.
+# Backups taken while the server is running are CRASH-CONSISTENT, not application-consistent.
+# For application-consistent backups, use a VolumeSnapshot after an RCON save command,
+# or use the panel's built-in backup function, or stop the server before archiving.
+backup:
+  # -- Enable the backup CronJob
+  enabled: false
+  # -- Cron schedule for backups
+  schedule: "0 4 * * *"
+  # -- Number of days to retain backup archives
+  retentionDays: 7
+  image:
+    # -- Image used for backup scripts (needs tar, find, date)
+    repository: alpine
+    tag: "3.19"
+    pullPolicy: IfNotPresent
+
+# VolumeSnapshot — create CSI snapshots before major upgrades
+volumeSnapshot:
+  # -- Enable snapshot creation (requires a CSI driver that supports VolumeSnapshots)
+  enabled: false
+  # -- VolumeSnapshotClass name (leave "" for cluster default)
+  snapshotClassName: ""
+  # -- Snapshot the game data PVC
+  data:
+    enabled: true
+  # -- Snapshot the server files PVC
+  serverFiles:
+    enabled: true
+
+# -- Node selector for pod scheduling
+nodeSelector: {}
+# -- Tolerations for pod scheduling
+tolerations: []
+# -- Affinity rules for pod scheduling
+affinity: {}

--- a/ct-install-skip.yaml
+++ b/ct-install-skip.yaml
@@ -11,3 +11,4 @@ excluded-charts:
   - ghost
   - n8n
   - remnant
+  - zomboid-server


### PR DESCRIPTION
## Summary

- Adds a new `zomboid-server` Helm chart (v0.1.0) for running a Project Zomboid dedicated server on Kubernetes
- Adds `zomboid-server` to `ct-install-skip.yaml` (game server image is not suitable for kind cluster install in CI)

## Chart overview

Single-replica StatefulSet with two containers:

| Container | Image |
|-----------|-------|
| `server` | `danixu86/project-zomboid-dedicated-server:41.78.19-release` |
| `panel` | `ghcr.io/fpsacha/zomboid-panel:v1.0.66` |

**Networking:** Cilium Gateway API HTTPRoute for the web panel; Cilium LoadBalancer for UDP game traffic (16261/16262).

**Storage (5 PVCs):** data (20Gi), serverFiles (30Gi), panelData (2Gi), panelLogs (disabled=emptyDir), backups (30Gi).

## Key design decisions

- **OnDelete update strategy** — template changes require manual pod deletion; crashes and node loss still trigger automatic recreation
- **Server security context is empty (`{}`)** — the danixu86 entrypoint runs as root to `chown` PVC dirs then `su - steam`; restricting it breaks startup
- **No preStop hook** — SIGTERM graceful shutdown is not verified in the upstream image; planned maintenance requires `save` + `quit` via RCON console before pod deletion
- **RCON_SKIP_SERVER_CHECK=true** — panel sidecar cannot inspect the server container process list; RCON commands still work
- **adminPasswordBootstrap** — ADMINPASSWORD only injected on first run to limit log exposure
- **shutdown.graceful.enabled: false** — placeholder values structure for a future RCON-based hook once a client binary is confirmed in the image

## Test plan

- [x] `helm lint --strict .` — 0 failures
- [x] `helm template` — 14 combinations (panel on/off, gateway, steam ports, existing secret, bootstrap, backup, snapshot, migration, PanelBridge, panelLogs PVC vs emptyDir)
- [x] No RCON port (27015) in any Service
- [x] `securityContext.server: {}` in rendered StatefulSet
- [x] No preStop hook rendered
- [x] `SELF_MANAGED_MODS` correctly spelled
- [x] No passwords rendered into NOTES, ConfigMaps, or README examples
- [x] `zomboid-server` added to `ct-install-skip.yaml` to skip kind install in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)