### PR TITLE
fix(zomboid-server): init container for server-files PVC + panel endpoints fix — 0.1.1

### DIFF
--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zomboid-server
 description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "41.78.19"
 home: https://projectzomboid.com
 icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,6 +1,6 @@
 # zomboid-server
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
 
 A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 
@@ -733,7 +733,7 @@ PZ saves are single-file-per-world. Two replicas writing to the same PVC would c
 | zomboid.selfManagedMods | bool | `false` | When true, the entrypoint will NOT modify Mods/WorkshopItems in the server INI. Use this after initial mod setup or when managing mods via the web panel. WARNING: when false and workshopIds/modIds are both empty, the entrypoint will CLEAR existing mod config in the INI file on every restart. |
 | zomboid.serverName | string | `"zomboid"` | Server name identifier (no spaces or special characters — admin login will fail) |
 | zomboid.serverPassword | string | `""` | Server join password (leave empty for no password) |
-| zomboid.serverPreset | string | `"Survival"` | Difficulty preset for a new server Options: Apocalypse, Beginner, Builder, FirstWeek, SixMonthsLater, Survival, Survivor |
+| zomboid.serverPreset | string | `"Survivor"` | Difficulty preset for a new server Options: Apocalypse, Beginner, Builder, FirstWeek, SixMonthsLater, Survivor |
 | zomboid.serverPresetReplace | bool | `false` | Replace the preset on every container start. Set true only during initial setup; set false afterwards to protect custom INI edits. |
 
 ----------------------------------------------

--- a/charts/zomboid-server/templates/service-panel.yaml
+++ b/charts/zomboid-server/templates/service-panel.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "zomboid-server.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.panel.type }}
+  publishNotReadyAddresses: true
   ports:
     - name: panel-http
       port: {{ .Values.service.panel.port }}

--- a/charts/zomboid-server/templates/statefulset.yaml
+++ b/charts/zomboid-server/templates/statefulset.yaml
@@ -24,6 +24,28 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        # Kubernetes does not auto-populate empty PVCs from image content (unlike Docker volumes).
+        # This init container copies the baked-in PZ server files to the server-files PVC on first
+        # boot so the entrypoint's preset validation and server binary can find them.
+        - name: init-server-files
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              if [ ! -f /mnt/start-server.sh ]; then
+                echo "Initializing server-files PVC from image..."
+                cp -a /home/steam/pz-dedicated/. /mnt/
+                chown -R 1000:1000 /mnt
+                echo "Done."
+              else
+                echo "server-files PVC already initialized, skipping."
+              fi
+          volumeMounts:
+            - name: server-files
+              mountPath: /mnt
       containers:
         # ── Game server ──────────────────────────────────────────────────────────
         - name: server

--- a/charts/zomboid-server/values.yaml
+++ b/charts/zomboid-server/values.yaml
@@ -72,8 +72,8 @@ zomboid:
   maxMemory: "4096m"
 
   # -- Difficulty preset for a new server
-  # Options: Apocalypse, Beginner, Builder, FirstWeek, SixMonthsLater, Survival, Survivor
-  serverPreset: "Survival"
+  # Options: Apocalypse, Beginner, Builder, FirstWeek, SixMonthsLater, Survivor
+  serverPreset: "Survivor"
   # -- Replace the preset on every container start.
   # Set true only during initial setup; set false afterwards to protect custom INI edits.
   serverPresetReplace: false


### PR DESCRIPTION
## Summary

- **Init container**: copies PZ game files from the baked-in image path to the `server-files` PVC on first boot. Kubernetes (unlike Docker) does not auto-populate empty PVCs from image content — this caused the entrypoint's preset validation to fail with `preset Survivor doesn't exists` because the PVC overlay hid the image files at `/home/steam/pz-dedicated`.
- **Panel service**: added `publishNotReadyAddresses: true` so the web panel is accessible via the gateway while the PZ server is still in its startup probe window (pod `1/2`).
- **Preset name**: fixed default `serverPreset: Survival → Survivor` (`Survival` is not a valid PZ preset name).
- **Chart**: bumped to `0.1.1`.

## Test plan

- [ ] Helm lint passes
- [ ] Fresh deploy: init container populates PVC, server starts without preset error
- [ ] Panel reachable at gateway hostname before server startup probe passes
- [ ] Existing deploy: init container skips copy (detects `start-server.sh` present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)