### PR TITLE
fix(zomboid-server): switch probes from pgrep to tcpSocket on RCON port — 0.1.2

### DIFF
--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zomboid-server
 description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "41.78.19"
 home: https://projectzomboid.com
 icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,6 +1,6 @@
 # zomboid-server
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
 
 A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 

--- a/charts/zomboid-server/templates/statefulset.yaml
+++ b/charts/zomboid-server/templates/statefulset.yaml
@@ -156,14 +156,11 @@ spec:
               mountPath: /backups
           resources:
             {{- toYaml .Values.resources.server | nindent 12 }}
-          # Startup probe — generous budget for first-start Steam and Workshop downloads
+          # Startup probe — TCP check on RCON port (pgrep not available in this image)
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
-            exec:
-              command:
-                - pgrep
-                - -f
-                - ProjectZomboid
+            tcpSocket:
+              port: rcon
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
@@ -171,11 +168,8 @@ spec:
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            exec:
-              command:
-                - pgrep
-                - -f
-                - ProjectZomboid
+            tcpSocket:
+              port: rcon
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
@@ -183,11 +177,8 @@ spec:
           {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            exec:
-              command:
-                - pgrep
-                - -f
-                - ProjectZomboid
+            tcpSocket:
+              port: rcon
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}


### PR DESCRIPTION
## Summary

`pgrep` is not installed in `danixu86/project-zomboid-dedicated-server`, causing all three probes (startup, readiness, liveness) to permanently error with `executable file not found in PATH`. The server container could never become Ready.

Switch to `tcpSocket` probe on the named `rcon` port (TCP 27015). RCON starts listening when the PZ server is fully initialised, making it a reliable health signal. No tools need to be installed in the container.

## Test plan

- [ ] CI passes
- [ ] After pod restart, startup probe passes once RCON is listening (~60-90s on existing world)
- [ ] Pod reaches `2/2 Running`
- [ ] Panel becomes accessible at gateway hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)