### PR TITLE
feat(zomboid-server): add metricRelabelings support to ServiceMonitor — 0.1.5

### DIFF
--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zomboid-server
 description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "41.78.19"
 home: https://projectzomboid.com
 icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,6 +1,6 @@
 # zomboid-server
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
 
 A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 
@@ -614,6 +614,18 @@ PZ saves are single-file-per-world. Two replicas writing to the same PVC would c
 | backup.image.tag | string | `"3.19"` |  |
 | backup.retentionDays | int | `7` | Number of days to retain backup archives |
 | backup.schedule | string | `"0 4 * * *"` | Cron schedule for backups |
+| exporter.enabled | bool | `false` | Enable the zomboid-exporter sidecar container |
+| exporter.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| exporter.image.repository | string | `"ghcr.io/janip81/zomboid-exporter"` | Image repository for zomboid-exporter |
+| exporter.image.tag | string | `"latest"` | Image tag — pin to a SHA or semver tag in production |
+| exporter.port | int | `9091` | Port the exporter listens on |
+| exporter.resources | object | `{"limits":{"cpu":"100m","memory":"64Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | Resources for the exporter sidecar |
+| exporter.serviceMonitor.enabled | bool | `false` | Create a Prometheus Operator ServiceMonitor for automatic scraping |
+| exporter.serviceMonitor.interval | string | `"30s"` | Scrape interval |
+| exporter.serviceMonitor.labels | object | `{}` | Additional labels on the ServiceMonitor (must match your Prometheus serviceMonitorSelector) |
+| exporter.serviceMonitor.metricRelabelings | list | `[]` | metricRelabelings applied after scrape; use to drop ephemeral labels that change on pod restart (instance, pod) to prevent duplicate series. |
+| exporter.serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout |
+| exporter.staleThreshold | string | `"120s"` | How long before an un-updated status file is treated as stale/down |
 | fullnameOverride | string | `""` | Provide a full name override for chart resources |
 | gateway.annotations | object | `{}` | Annotations on the HTTPRoute resource |
 | gateway.enabled | bool | `false` | Enable the HTTPRoute for the panel |
@@ -733,6 +745,7 @@ PZ saves are single-file-per-world. Two replicas writing to the same PVC would c
 | zomboid.selfManagedMods | bool | `false` | When true, the entrypoint will NOT modify Mods/WorkshopItems in the server INI. Use this after initial mod setup or when managing mods via the web panel. WARNING: when false and workshopIds/modIds are both empty, the entrypoint will CLEAR existing mod config in the INI file on every restart. |
 | zomboid.serverName | string | `"zomboid"` | Server name identifier (no spaces or special characters — admin login will fail) |
 | zomboid.serverPassword | string | `""` | Server join password (leave empty for no password) |
+| zomboid.serverPasswordEnabled | bool | `false` | Set to true to enable the PASSWORD env var when using existingSecret |
 | zomboid.serverPreset | string | `"Survivor"` | Difficulty preset for a new server Options: Apocalypse, Beginner, Builder, FirstWeek, SixMonthsLater, Survivor |
 | zomboid.serverPresetReplace | bool | `false` | Replace the preset on every container start. Set true only during initial setup; set false afterwards to protect custom INI edits. |
 

--- a/charts/zomboid-server/templates/servicemonitor.yaml
+++ b/charts/zomboid-server/templates/servicemonitor.yaml
@@ -19,4 +19,8 @@ spec:
       interval: {{ .Values.exporter.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.exporter.serviceMonitor.scrapeTimeout }}
       path: /metrics
+      {{- with .Values.exporter.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/zomboid-server/values.yaml
+++ b/charts/zomboid-server/values.yaml
@@ -208,6 +208,9 @@ exporter:
     interval: "30s"
     # -- Scrape timeout
     scrapeTimeout: "10s"
+    # -- metricRelabelings applied after scrape; use to drop ephemeral labels
+    # that change on pod restart (instance, pod) to prevent duplicate series.
+    metricRelabelings: []
 
 # Services
 service:


### PR DESCRIPTION
## Summary

- Adds optional `metricRelabelings` to the ServiceMonitor endpoint template so callers can drop ephemeral per-pod labels at ingest time
- Drops `instance`, `pod`, `container`, `endpoint` labels in the zomboid deployment — prevents Prometheus from creating duplicate time series across pod restarts (StatefulSet pod IP changes on every restart)
- Bumps chart to `0.1.5`

## Background

Every `zomboid_*` metric carries an `instance=<pod-ip>:9091` label. Since pod IP changes on restart, Prometheus creates a new time series per restart and holds the old one for ~5 minutes (stale window). This caused 3× duplicate series in Grafana after multiple restarts. Dropping the label at scrape time via `metricRelabelings` means the series is continuous across restarts.

## Test plan

- [ ] `helm template` renders ServiceMonitor with `metricRelabelings` when values are set
- [ ] Default `metricRelabelings: []` renders ServiceMonitor without the field (backward-compatible)
- [ ] After ArgoCD syncs, confirm `kubectl get servicemonitor zomboid-zomboid-server -n zomboid -o yaml` shows the relabeling rules
- [ ] After next pod restart, confirm Grafana shows one continuous series per metric (no duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)