### PR TITLE
fix(ghost): bump to 6.37.0 - critical security update

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ghost
 description: Ghost blogging platform with external MySQL/MariaDB
 type: application
-version: 0.1.1
-appVersion: "6.32.0"
+version: 0.1.2
+appVersion: "6.37.0"
 home: https://github.com/janip81/helm-charts/tree/main/charts/ghost
 icon: https://ghost.org/favicon.ico
 keywords:
@@ -25,3 +25,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Optional SMTP mail configuration
+    - kind: security
+      description: Bump Ghost to 6.37.0 (fixes GHSA-62q6-4hv4-vjrw, critical cache-poisoning XSS)

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -1,6 +1,6 @@
 # ghost
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.32.0](https://img.shields.io/badge/AppVersion-6.32.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.37.0](https://img.shields.io/badge/AppVersion-6.37.0-informational?style=flat-square)
 
 Ghost blogging platform with external MySQL/MariaDB
 


### PR DESCRIPTION
## Summary
- Ghost bumped 6.32.0 -> 6.37.0
- Fixes GHSA-62q6-4hv4-vjrw (critical cache-poisoning XSS, affects >=4.0.0 <=6.36.0)
- Chart version 0.1.1 -> 0.1.2

## Test plan
- [ ] CI lint/test passes
- [ ] ArgoCD syncs prod-k8s ghost app to new chart version
- [ ] Verify blog.threshold.se loads correctly on 6.37.0