### PR TITLE
capi-cluster 0.0.100: add nodeZoneSync addon for multi-host clusters

### DIFF
--- a/charts/capi-cluster/Chart.yaml
+++ b/charts/capi-cluster/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.99
+version: 0.0.100
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/capi-cluster/templates/NodeZoneSync.yaml
+++ b/charts/capi-cluster/templates/NodeZoneSync.yaml
@@ -1,0 +1,148 @@
+{{- if .Values.nodeZoneSync.enabled }}
+# Keeps topology.kubernetes.io/zone (and the legacy failure-domain.beta.* alias)
+# correct on every node of the WORKLOAD cluster, sourced from CAPV's own
+# VSphereVM.status.host — which CAPV re-verifies against live vCenter on its
+# normal reconcile loop (~5-6min), unlike vsphere-cpi's node label which is
+# only set once at node registration and never touched again.
+#
+# Runs here on prod-mgmt (not in the workload cluster) because VSphereVM
+# objects only exist on the management cluster. Reaches the workload cluster
+# using the {{ .Values.cluster.name }}-kubeconfig Secret CAPI already creates
+# in this same namespace — no vCenter credentials needed anywhere in this job.
+#
+# hostZoneMap is deliberately explicit, not derived from the ESXi hostname:
+# the vSphere tag a host carries can be an arbitrary/legacy name (e.g.
+# prod-k8s's stargate-prod host keeps the tag "k8s-stockholm" so existing
+# PVs' baked-in nodeAffinity keeps matching — PersistentVolume.spec.nodeAffinity
+# is immutable, so this "wrong-looking" name is intentional, not a leftover).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.cluster.name }}-node-zone-sync
+  namespace: {{ .Values.cluster.name }}
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.cluster.name }}-node-zone-sync
+  namespace: {{ .Values.cluster.name }}
+rules:
+  - apiGroups: ["infrastructure.cluster.x-k8s.io"]
+    resources: ["vspherevms"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["{{ .Values.cluster.name }}-kubeconfig"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.cluster.name }}-node-zone-sync
+  namespace: {{ .Values.cluster.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.cluster.name }}-node-zone-sync
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.cluster.name }}-node-zone-sync
+    namespace: {{ .Values.cluster.name }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Values.cluster.name }}-node-zone-sync
+  namespace: {{ .Values.cluster.name }}
+spec:
+  schedule: {{ .Values.nodeZoneSync.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.nodeZoneSync.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.nodeZoneSync.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Values.cluster.name }}-node-zone-sync
+          restartPolicy: OnFailure
+          containers:
+            - name: node-zone-sync
+              image: {{ .Values.nodeZoneSync.image | quote }}
+              env:
+                - name: NAMESPACE
+                  value: {{ .Values.cluster.name | quote }}
+                - name: KUBECONFIG_SECRET
+                  value: {{ .Values.cluster.name }}-kubeconfig
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+
+                  # Static host -> zone-tag map, baked in from values at render time.
+                  zone_for_host() {
+                    case "$1" in
+                  {{- range $host, $zone := .Values.nodeZoneSync.hostZoneMap }}
+                      "{{ $host }}") echo "{{ $zone }}" ;;
+                  {{- end }}
+                      *) echo "" ;;
+                    esac
+                  }
+
+                  # Read VSphereVM host placement first, using the pod's own
+                  # in-cluster identity (this targets prod-mgmt, where the
+                  # job runs). KUBECONFIG is unset at this point, so kubectl
+                  # uses the mounted ServiceAccount token, not the workload
+                  # cluster kubeconfig extracted below.
+                  echo "=== Reading VSphereVM host placement (management cluster) ==="
+                  # jsonpath (single-brace syntax) on purpose, not go-template —
+                  # this whole file is itself Helm-templated, so double-brace
+                  # syntax here would get parsed by Helm instead of passed
+                  # through to kubectl.
+                  kubectl -n "$NAMESPACE" get vspherevm \
+                    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.host}{"\n"}{end}' \
+                    > /tmp/vm-hosts.txt
+                  echo "Found $(wc -l < /tmp/vm-hosts.txt) VSphereVM objects in $NAMESPACE"
+
+                  echo "=== Extracting target cluster kubeconfig ==="
+                  kubectl get secret "$KUBECONFIG_SECRET" -n "$NAMESPACE" \
+                    -o jsonpath='{.data.value}' | base64 -d > /tmp/target.kubeconfig
+                  export KUBECONFIG=/tmp/target.kubeconfig
+
+                  # Everything from here targets the workload cluster.
+                  while IFS=$'\t' read -r NAME HOST; do
+                    if [ -z "$HOST" ]; then
+                      echo "  $NAME: no .status.host yet, skipping"
+                      continue
+                    fi
+
+                    ZONE=$(zone_for_host "$HOST")
+                    if [ -z "$ZONE" ]; then
+                      echo "  $NAME: host '$HOST' not in hostZoneMap, skipping"
+                      continue
+                    fi
+
+                    CURRENT=$(kubectl get node "$NAME" \
+                      -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}' \
+                      2>/dev/null || true)
+
+                    if [ -z "$CURRENT" ]; then
+                      echo "  $NAME: node not found in workload cluster yet, skipping"
+                      continue
+                    fi
+
+                    if [ "$CURRENT" = "$ZONE" ]; then
+                      echo "  $NAME: zone already correct ($ZONE)"
+                      continue
+                    fi
+
+                    echo "  $NAME: zone drift detected ($CURRENT -> $ZONE), patching"
+                    kubectl label node "$NAME" \
+                      topology.kubernetes.io/zone="$ZONE" \
+                      failure-domain.beta.kubernetes.io/zone="$ZONE" \
+                      --overwrite
+                  done < /tmp/vm-hosts.txt
+
+                  echo "=== Done ==="
+{{- end }}

--- a/charts/capi-cluster/values.yaml
+++ b/charts/capi-cluster/values.yaml
@@ -228,3 +228,27 @@ etcdDefrag:
   image: ""                       # leave empty to auto-detect from k8s version
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+
+# Keeps each workload node's topology.kubernetes.io/zone label in sync with
+# CAPV's own VSphereVM.status.host — fixes vsphere-cpi only setting this once
+# at node registration, which goes stale after any manual storage vMotion.
+# Runs on prod-mgmt (this chart's own cluster), reaching the workload cluster
+# via the {{ cluster.name }}-kubeconfig Secret CAPI already creates here.
+# Only useful once a cluster's nodes genuinely span more than one ESXi host
+# with non-shared per-host datastores — leave disabled otherwise.
+nodeZoneSync:
+  enabled: false
+  schedule: "*/5 * * * *"        # matches CAPV's own VSphereVM resync cadence
+  image: "docker.io/bitnami/kubectl:latest"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  # ESXi hostname (VSphereVM.status.host) -> zone tag value.
+  # Not auto-derived from the hostname on purpose: the vSphere tag a host
+  # carries can be an intentionally "wrong-looking" legacy name (see
+  # prod-k8s's values — stargate-prod host keeps the tag "k8s-stockholm" so
+  # existing PVs' immutable nodeAffinity keeps matching). Must match whatever
+  # is actually configured in vsphere-csi/vsphere-cpi's labels.zone lookup
+  # for this same vCenter.
+  hostZoneMap: {}
+  # stargate-prod.server.threshold.se: k8s-stockholm
+  # stargate-burst.server.threshold.se: stargate-burst


### PR DESCRIPTION
## Summary

Adds an optional CronJob addon (`nodeZoneSync`, disabled by default) that keeps `topology.kubernetes.io/zone` correct on workload-cluster nodes, sourced from CAPV's own `VSphereVM.status.host` — which CAPV re-verifies against live vCenter on its normal reconcile loop, unlike `vsphere-cpi`'s node label which is set once at registration and never refreshed.

**Why**: hit this directly on prod-k8s tonight while splitting a shared vSphere zone tag into per-host tags — required manually relabeling 8 nodes and restarting csi-node pods after every host-placement change. This automates that recovery going forward.

**Where it runs**: on the management cluster (prod-mgmt), in the same per-cluster namespace the rest of this chart's CAPI resources already live in. Reads `VSphereVM` objects locally, then reaches the workload cluster via the `<cluster>-kubeconfig` Secret CAPI already creates there. No vCenter credentials anywhere in the job.

**Safety**:
- Disabled by default (`nodeZoneSync.enabled: false`) — bumping `targetRevision` alone changes nothing live.
- Purely additive — doesn't touch any `Machine`/`MachineDeployment`/`KubeadmControlPlane`/`VSphereMachineTemplate` resource, so unlike most capi-cluster changes this can't trigger a node rolling-replacement.
- Only reads (VSphereVMs, one Secret, Nodes) plus one write type (`kubectl label node --overwrite`) — no deletes anywhere.
- `hostZoneMap` is an explicit host→zone-tag map in values, not derived from the hostname (a host's vSphere tag can be an intentionally legacy-looking name so existing PVs' immutable `nodeAffinity` keeps matching).

## Test plan

- [x] `helm lint --strict` passes
- [x] `helm template` renders valid YAML, verified with a real host→zone map
- [x] Extracted CronJob script passes `bash -n` syntax check
- [x] Confirmed RBAC resource name (`vspherevms.infrastructure.cluster.x-k8s.io`) matches the live CRD
- [ ] dev-k8s validation — **not possible**, dev-k8s is currently deleted/not provisioned
- [ ] Plan: enable on prod-k8s with `enabled: true` first, manually trigger one run (`kubectl create job --from=cronjob/... test-run`) and inspect logs before trusting the recurring schedule — chosen specifically because this change can't touch Machine-level resources, unlike typical capi-cluster changes that need dev-first testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KtoaLTPqHEHqN77yMkL4y