### PR TITLE
fix(zomboid-server): work around panel entrypoint chown failure under non-root securityContext

### DIFF
--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zomboid-server
 description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "41.78.19"
 home: https://projectzomboid.com
 icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png
@@ -30,4 +30,4 @@ annotations:
     - name: zomboid-server
       image: danixu86/project-zomboid-dedicated-server:41.78.19-release
     - name: zomboid-panel
-      image: ghcr.io/fpsacha/zomboid-panel:v1.0.67
+      image: ghcr.io/fpsacha/zomboid-panel:v1.1.29

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,6 +1,6 @@
 # zomboid-server
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
 
 A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 

--- a/charts/zomboid-server/templates/statefulset.yaml
+++ b/charts/zomboid-server/templates/statefulset.yaml
@@ -46,6 +46,33 @@ spec:
           volumeMounts:
             - name: server-files
               mountPath: /mnt
+        # The panel image's entrypoint (since its v1.1.24 PUID/PGID support) assumes it
+        # starts as root, chowns /app/data and /app/logs to PUID:PGID, then drops
+        # privileges via setpriv. Our panel container's securityContext already forces
+        # a fixed non-root runAsUser/runAsGroup, so it never runs as root and that
+        # chown fails outright (CrashLoopBackOff) -- see
+        # https://github.com/fpsacha/zomboid-control-panel/issues/33. Adding just the
+        # CHOWN capability to the panel container does not work around it: Kubernetes
+        # does not propagate added capabilities into the effective set for non-root
+        # containers, only the bounding set (confirmed live via /proc/1/status).
+        # Fix: pre-chown these volumes here as root, once, before the panel container
+        # starts -- it then bypasses the broken entrypoint entirely (see the panel
+        # container's `command` override below) since ownership is already correct.
+        - name: init-panel-data
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - chown -R 1000:1000 /app/data /app/logs
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
+          volumeMounts:
+            - name: panel-data
+              mountPath: /app/data
+            - name: panel-logs
+              mountPath: /app/logs
       containers:
         # ── Game server ──────────────────────────────────────────────────────────
         - name: server
@@ -192,6 +219,11 @@ spec:
         - name: panel
           image: "{{ .Values.panel.image.repository }}:{{ .Values.panel.image.tag }}"
           imagePullPolicy: {{ .Values.panel.image.pullPolicy }}
+          # Bypass the image's default entrypoint (chown + setpriv drop-privileges dance --
+          # see the init-panel-data comment above for why that breaks under our fixed
+          # non-root securityContext) and exec the app directly, matching the image's
+          # own Dockerfile CMD.
+          command: ["node", "server/index.js"]
           securityContext:
             {{- toYaml .Values.securityContext.panel | nindent 12 }}
           env:


### PR DESCRIPTION
## Summary
- The panel image's entrypoint (since v1.1.24's PUID/PGID support) assumes it starts as root, chowns `/app/data`/`/app/logs`, then drops privileges via `setpriv`. Our panel container's securityContext already forces a fixed non-root `runAsUser`/`runAsGroup`, so it never runs as root and the `chown` fails outright (`CrashLoopBackOff`).
- Adding just the `CHOWN` capability doesn't work around it — Kubernetes doesn't propagate added capabilities into the effective set for non-root containers, only the bounding set (confirmed live via `/proc/1/status`).
- Adds `init-panel-data` init container (root, one-shot) to pre-chown `panel-data`/`panel-logs` to `1000:1000` before the main containers start.
- Overrides the panel container's `command` to exec `node server/index.js` directly, bypassing the broken entrypoint entirely.
- Bumps chart to `0.1.6`.
- Upstream issue filed against the panel repo (workaround documented there too).

## Test plan
- [x] Verified live in prod-k8s: applied the equivalent patch directly to the running StatefulSet, confirmed panel container starts clean on v1.1.29 (`ready=true`, 0 restarts, RCON/Bridge connected)
- [x] Confirmed the CHOWN-capability-only approach does NOT work (documented in the commit message so it isn't retried)
- [ ] `helm template`/`ct lint` CI checks