### PR TITLE
fix(zomboid-server): drop panel command override, upstream fixed non-root entrypoint

### DIFF
--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zomboid-server
 description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "41.78.19"
 home: https://projectzomboid.com
 icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png
@@ -30,4 +30,4 @@ annotations:
     - name: zomboid-server
       image: danixu86/project-zomboid-dedicated-server:41.78.19-release
     - name: zomboid-panel
-      image: ghcr.io/fpsacha/zomboid-panel:v1.1.29
+      image: ghcr.io/fpsacha/zomboid-panel:v1.1.34

--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: zomboid-server
 description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 type: application
-version: 0.1.7
-appVersion: "41.78.19"
+version: 0.1.8
+appVersion: "42.20.2"
 home: https://projectzomboid.com
 icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png
 maintainers:
@@ -28,6 +28,6 @@ annotations:
       url: https://github.com/fpsacha/zomboid-control-panel
   artifacthub.io/images: |
     - name: zomboid-server
-      image: danixu86/project-zomboid-dedicated-server:41.78.19-release
+      image: danixu86/project-zomboid-dedicated-server:42.20.2-release
     - name: zomboid-panel
       image: ghcr.io/fpsacha/zomboid-panel:v1.1.34

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,6 +1,6 @@
 # zomboid-server
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 42.20.2](https://img.shields.io/badge/AppVersion-42.20.2-informational?style=flat-square)
 
 A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 
@@ -631,10 +631,10 @@ PZ saves are single-file-per-world. Two replicas writing to the same PVC would c
 | gateway.enabled | bool | `false` | Enable the HTTPRoute for the panel |
 | gateway.hostname | string | `"zomboid.example.com"` | Hostname the panel should be reachable on |
 | gateway.parentRefs | list | `[{"name":"main-gateway","namespace":"gateway"}]` | Parent gateway references |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"danixu86/project-zomboid-dedicated-server","tag":"41.78.19-release"}` | Docker image for the Project Zomboid dedicated server. Build 41 vs Build 42 is determined by the image tag — STEAMAPPBRANCH is baked at build time. Build 41 (stable):       danixu86/project-zomboid-dedicated-server:41.78.19-release Build 42 (early access): danixu86/project-zomboid-dedicated-server:42.19.0-unstable |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"danixu86/project-zomboid-dedicated-server","tag":"42.20.2-release"}` | Docker image for the Project Zomboid dedicated server. Build 42 is now the "release" branch upstream (Build 41's last tag, 41.78.19-release, hasn't been updated since 2026-04-09 — Build 42 has superseded it as the actively maintained stable line, tagged *-release rather than *-unstable since 42.20.0). Build 42 (stable):  danixu86/project-zomboid-dedicated-server:42.20.2-release Build 41 (legacy):  danixu86/project-zomboid-dedicated-server:41.78.19-release |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"danixu86/project-zomboid-dedicated-server"` | Docker repository for the server image |
-| image.tag | string | 41.78.19-release (Build 41 stable) | Image tag. Pin to a specific version; floating tags are discouraged in production. |
+| image.tag | string | 42.20.2-release (Build 42 stable) | Image tag. Pin to a specific version; floating tags are discouraged in production. |
 | livenessProbe.enabled | bool | `false` | Enable liveness probe |
 | livenessProbe.failureThreshold | int | `6` |  |
 | livenessProbe.initialDelaySeconds | int | `300` |  |

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,6 +1,6 @@
 # zomboid-server
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 41.78.19](https://img.shields.io/badge/AppVersion-41.78.19-informational?style=flat-square)
 
 A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 

--- a/charts/zomboid-server/templates/statefulset.yaml
+++ b/charts/zomboid-server/templates/statefulset.yaml
@@ -46,18 +46,16 @@ spec:
           volumeMounts:
             - name: server-files
               mountPath: /mnt
-        # The panel image's entrypoint (since its v1.1.24 PUID/PGID support) assumes it
-        # starts as root, chowns /app/data and /app/logs to PUID:PGID, then drops
-        # privileges via setpriv. Our panel container's securityContext already forces
-        # a fixed non-root runAsUser/runAsGroup, so it never runs as root and that
-        # chown fails outright (CrashLoopBackOff) -- see
-        # https://github.com/fpsacha/zomboid-control-panel/issues/33. Adding just the
-        # CHOWN capability to the panel container does not work around it: Kubernetes
-        # does not propagate added capabilities into the effective set for non-root
-        # containers, only the bounding set (confirmed live via /proc/1/status).
-        # Fix: pre-chown these volumes here as root, once, before the panel container
-        # starts -- it then bypasses the broken entrypoint entirely (see the panel
-        # container's `command` override below) since ownership is already correct.
+        # The panel image's entrypoint (since its v1.1.24 PUID/PGID support) originally
+        # assumed it started as root to chown /app/data and /app/logs, then drop
+        # privileges via setpriv -- which crash-looped under our fixed non-root
+        # securityContext (see https://github.com/fpsacha/zomboid-control-panel/issues/33).
+        # Fixed upstream since v1.1.30: the entrypoint now detects it's already
+        # non-root (id -u != 0) and skips chown/setpriv entirely, exec'ing the app
+        # directly -- but it still requires /app/data and /app/logs to already be
+        # writable by the container's UID:GID, since it no longer chowns them itself.
+        # This init container does that pre-chown, once, as root, before the panel
+        # container starts. Still required even on current panel versions.
         - name: init-panel-data
           image: busybox:1.36
           command:
@@ -219,11 +217,9 @@ spec:
         - name: panel
           image: "{{ .Values.panel.image.repository }}:{{ .Values.panel.image.tag }}"
           imagePullPolicy: {{ .Values.panel.image.pullPolicy }}
-          # Bypass the image's default entrypoint (chown + setpriv drop-privileges dance --
-          # see the init-panel-data comment above for why that breaks under our fixed
-          # non-root securityContext) and exec the app directly, matching the image's
-          # own Dockerfile CMD.
-          command: ["node", "server/index.js"]
+          # No command override needed as of panel v1.1.30+ -- its entrypoint now
+          # detects non-root and execs the default CMD itself (see the
+          # init-panel-data comment above).
           securityContext:
             {{- toYaml .Values.securityContext.panel | nindent 12 }}
           env:

--- a/charts/zomboid-server/values.yaml
+++ b/charts/zomboid-server/values.yaml
@@ -1,13 +1,16 @@
 # -- Docker image for the Project Zomboid dedicated server.
-# Build 41 vs Build 42 is determined by the image tag — STEAMAPPBRANCH is baked at build time.
-# Build 41 (stable):       danixu86/project-zomboid-dedicated-server:41.78.19-release
-# Build 42 (early access): danixu86/project-zomboid-dedicated-server:42.19.0-unstable
+# Build 42 is now the "release" branch upstream (Build 41's last tag,
+# 41.78.19-release, hasn't been updated since 2026-04-09 — Build 42 has
+# superseded it as the actively maintained stable line, tagged *-release
+# rather than *-unstable since 42.20.0).
+# Build 42 (stable):  danixu86/project-zomboid-dedicated-server:42.20.2-release
+# Build 41 (legacy):  danixu86/project-zomboid-dedicated-server:41.78.19-release
 image:
   # -- Docker repository for the server image
   repository: danixu86/project-zomboid-dedicated-server
   # -- Image tag. Pin to a specific version; floating tags are discouraged in production.
-  # @default -- 41.78.19-release (Build 41 stable)
-  tag: "41.78.19-release"
+  # @default -- 42.20.2-release (Build 42 stable)
+  tag: "42.20.2-release"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Panel v1.1.30+ fixed the entrypoint bug we reported in fpsacha/zomboid-control-panel#33: it now checks `id -u` and skips the chown+setpriv dance when already non-root, exec'ing the default CMD itself.
- Removes our `command: ["node", "server/index.js"]` override from the panel container — it was a workaround for the old broken entrypoint and is no longer needed.
- Keeps the `init-panel-data` init container — still required, since the fixed entrypoint explicitly documents that `/app/data`/`/app/logs` must already be writable by the container's UID:GID (it no longer chowns them itself when non-root).
- Bumps panel image to `v1.1.34`.
- Bumps the chart's **default** server image from `41.78.19-release` (Build 41, last updated 2026-04-09) to `42.20.2-release` (Build 42, now the actively maintained "release" line). Updates `appVersion` and the artifacthub image annotation to match.
- Bumps chart to `0.1.8`.

## Test plan
- [x] Verified upstream panel fix live: fetched `docker/entrypoint.sh` at `v1.1.34`, confirmed the `id -u != 0` check and graceful skip-and-exec path
- [x] Confirmed `42.20.2-release` is the latest Build 42 stable tag on Docker Hub
- [ ] Deploy to prod-k8s and confirm panel starts clean without the command override
- [ ] `helm template`/`ct lint` CI checks