### PR TITLE
feat(zomboid-server): optional Postgres DSN for the exporter's PerkLog history

### DIFF
--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zomboid-server
 description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "42.20.2"
 home: https://projectzomboid.com
 icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,6 +1,6 @@
 # zomboid-server
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 42.20.2](https://img.shields.io/badge/AppVersion-42.20.2-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 42.20.2](https://img.shields.io/badge/AppVersion-42.20.2-informational?style=flat-square)
 
 A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 
@@ -614,6 +614,7 @@ PZ saves are single-file-per-world. Two replicas writing to the same PVC would c
 | backup.image.tag | string | `"3.19"` |  |
 | backup.retentionDays | int | `7` | Number of days to retain backup archives |
 | backup.schedule | string | `"0 4 * * *"` | Cron schedule for backups |
+| exporter.database | object | `{"enabled":false,"existingSecret":"","existingSecretPasswordKey":"db-password","host":"","name":"zomboid","port":5432,"user":"zomboid"}` | Optional Postgres persistence for PerkLog event history (deaths, respawns, skill progression) and leaderboards. Entirely optional -- the exporter runs fine for Prometheus/Grafana with this disabled, it just won't have player/death/skill history beyond current counters. Password is read from existingSecret's existingSecretPasswordKey via Kubernetes' native $(VAR) arg substitution -- no separate DSN secret needed. |
 | exporter.enabled | bool | `false` | Enable the zomboid-exporter sidecar container |
 | exporter.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | exporter.image.repository | string | `"ghcr.io/janip81/zomboid-exporter"` | Image repository for zomboid-exporter |

--- a/charts/zomboid-server/templates/statefulset.yaml
+++ b/charts/zomboid-server/templates/statefulset.yaml
@@ -316,6 +316,17 @@ spec:
             - --data-path=/data
             - --web.listen-address=:{{ .Values.exporter.port }}
             - --stale-threshold={{ .Values.exporter.staleThreshold }}
+            {{- if .Values.exporter.database.enabled }}
+            - --db-dsn=postgres://{{ .Values.exporter.database.user }}:$(EXPORTER_DB_PASSWORD)@{{ .Values.exporter.database.host }}:{{ .Values.exporter.database.port }}/{{ .Values.exporter.database.name }}
+            {{- end }}
+          {{- if .Values.exporter.database.enabled }}
+          env:
+            - name: EXPORTER_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.exporter.database.existingSecret }}
+                  key: {{ .Values.exporter.database.existingSecretPasswordKey }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.exporter.port }}

--- a/charts/zomboid-server/values.yaml
+++ b/charts/zomboid-server/values.yaml
@@ -194,6 +194,21 @@ exporter:
   port: 9091
   # -- How long before an un-updated status file is treated as stale/down
   staleThreshold: "120s"
+  # -- Optional Postgres persistence for PerkLog event history (deaths,
+  # respawns, skill progression) and leaderboards. Entirely optional --
+  # the exporter runs fine for Prometheus/Grafana with this disabled, it
+  # just won't have player/death/skill history beyond current counters.
+  # Password is read from existingSecret's existingSecretPasswordKey via
+  # Kubernetes' native $(VAR) arg substitution -- no separate DSN secret
+  # needed.
+  database:
+    enabled: false
+    host: ""
+    port: 5432
+    name: zomboid
+    user: zomboid
+    existingSecret: ""
+    existingSecretPasswordKey: db-password
   # -- Resources for the exporter sidecar
   resources:
     requests:


### PR DESCRIPTION
## Summary
- `zomboid-exporter` (companion PR: janip81/zomboid-exporter) now tails `PerkLog.txt` for deaths/respawns/skill level-ups, on top of the Prometheus counters it always exposed.
- Adds `exporter.database.*` values (disabled by default) to optionally point the exporter at Postgres for event history + future leaderboards.
- Password is wired via Kubernetes' native `$(VAR)` arg substitution from an `existingSecret` — no separate DSN secret to manage.
- Bumps chart to `0.1.9`.

## Test plan
- [ ] Deploy with `exporter.database.enabled: true` pointed at our `pg-main` CNPG cluster, confirm the exporter connects and PerkLog events land in Postgres
- [ ] `helm template`/`ct lint` CI checks