### PR TITLE
zomboid-server: wire Discord bot slash commands

### DIFF
--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zomboid-server
 description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "42.20.2"
 home: https://projectzomboid.com
 icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,6 +1,6 @@
 # zomboid-server
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 42.20.2](https://img.shields.io/badge/AppVersion-42.20.2-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 42.20.2](https://img.shields.io/badge/AppVersion-42.20.2-informational?style=flat-square)
 
 A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 
@@ -614,6 +614,8 @@ PZ saves are single-file-per-world. Two replicas writing to the same PVC would c
 | backup.image.tag | string | `"3.19"` |  |
 | backup.retentionDays | int | `7` | Number of days to retain backup archives |
 | backup.schedule | string | `"0 4 * * *"` | Cron schedule for backups |
+| discordBot.adminUserIds | list | `[]` | Discord user IDs (snowflakes) allowed to run admin-tier slash commands (currently just /save). Rendered into a ConfigMap (templates/configmap-discord-bot.yaml) rather than baked into the Deployment args, so it's editable via git without an image rebuild. Empty means no admin commands can be run by anyone. |
+| discordBot.appId | string | `""` |  |
 | discordBot.channelId | string | `""` |  |
 | discordBot.database | object | `{"enabled":false,"existingSecret":"","existingSecretPasswordKey":"db-password","host":"","name":"zomboid","port":5432,"user":"zomboid"}` | Stats/leaderboard queries against the same Postgres DB the exporter writes to. Typically the same existingSecret/keys as exporter.database. |
 | discordBot.discordToken.existingSecret | string | `""` |  |

--- a/charts/zomboid-server/templates/configmap-discord-bot.yaml
+++ b/charts/zomboid-server/templates/configmap-discord-bot.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.discordBot.enabled }}
+# Git-editable bot config that isn't a secret and doesn't warrant an image
+# rebuild to change -- currently just the admin-command authorization
+# allowlist. Deliberately separate from Discord server roles/permissions
+# (see admin.go in discord-bot -- who administers the Discord server and
+# who should have game-admin rights aren't necessarily the same people).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "zomboid-server.fullname" . }}-discord-bot-config
+  labels:
+    {{- include "zomboid-server.labels" . | nindent 4 }}
+data:
+  # Built manually (not `toJson`) and each ID force-quoted -- Discord
+  # snowflake IDs are 17-19 digit numbers, and toJson on an unquoted YAML
+  # list renders them as JSON numbers, silently losing precision past
+  # float64's ~15-17 significant digits and breaking the []string decode
+  # in admin.go.
+  admin-user-ids.json: |
+    [{{- range $i, $id := (.Values.discordBot.adminUserIds | default list) }}{{ if $i }},{{ end }}{{ $id | quote }}{{- end }}]
+{{- end }}

--- a/charts/zomboid-server/templates/deployment-discord-bot.yaml
+++ b/charts/zomboid-server/templates/deployment-discord-bot.yaml
@@ -23,9 +23,16 @@ spec:
           image: "{{ .Values.discordBot.image.repository }}:{{ .Values.discordBot.image.tag }}"
           imagePullPolicy: {{ .Values.discordBot.image.pullPolicy }}
           args:
+            - --server-name={{ .Values.zomboid.serverName }}
             - --rcon-host={{ .Values.discordBot.rcon.host | default (printf "%s-rcon" (include "zomboid-server.fullname" .)) }}:{{ .Values.discordBot.rcon.port }}
             {{- if .Values.discordBot.channelId }}
             - --discord-channel-id={{ .Values.discordBot.channelId }}
+            {{- end }}
+            {{- if .Values.discordBot.appId }}
+            - --discord-app-id={{ .Values.discordBot.appId }}
+            {{- end }}
+            {{- if .Values.exporter.enabled }}
+            - --metrics-url=http://{{ include "zomboid-server.fullname" . }}-metrics:{{ .Values.exporter.port }}/metrics
             {{- end }}
             {{- if .Values.discordBot.mqtt.broker }}
             - --mqtt-broker={{ .Values.discordBot.mqtt.broker }}
@@ -65,6 +72,14 @@ spec:
                   name: {{ .Values.discordBot.database.existingSecret }}
                   key: {{ .Values.discordBot.database.existingSecretPasswordKey }}
             {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
           resources:
             {{- toYaml .Values.discordBot.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "zomboid-server.fullname" . }}-discord-bot-config
 {{- end }}

--- a/charts/zomboid-server/values.yaml
+++ b/charts/zomboid-server/values.yaml
@@ -268,6 +268,16 @@ discordBot:
   # just a snowflake ID. Empty means events are received and logged but
   # never posted (useful for testing the MQTT connection on its own).
   channelId: ""
+  # -- Discord Application ID. Not a secret -- required to register slash
+  # commands (/online, /serveruptime, /save). Empty means slash commands
+  # are never registered.
+  appId: ""
+  # -- Discord user IDs (snowflakes) allowed to run admin-tier slash
+  # commands (currently just /save). Rendered into a ConfigMap
+  # (templates/configmap-discord-bot.yaml) rather than baked into the
+  # Deployment args, so it's editable via git without an image rebuild.
+  # Empty means no admin commands can be run by anyone.
+  adminUserIds: []
   rcon:
     # -- RCON host:port to connect to. Empty uses this release's own RCON
     # Service (created automatically when discordBot.enabled is true).


### PR DESCRIPTION
## Summary
- New `discordBot.appId` value registers slash commands (`/online`, `/serveruptime`, `/save`)
- New `discordBot.adminUserIds` value renders into a new ConfigMap (git-editable, no rebuild) for admin-command authorization
- Wires `--metrics-url` (from the exporter's existing `-metrics` Service) and `--server-name` through to the bot

Chart 0.1.10 -> 0.1.11.