### PR TITLE
zomboid-server: wire discordBot.guildId for instant slash commands

### DIFF
--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zomboid-server
 description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 type: application
-version: 0.1.12
+version: 0.1.13
 appVersion: "42.20.2"
 home: https://projectzomboid.com
 icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,6 +1,6 @@
 # zomboid-server
 
-![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 42.20.2](https://img.shields.io/badge/AppVersion-42.20.2-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 42.20.2](https://img.shields.io/badge/AppVersion-42.20.2-informational?style=flat-square)
 
 A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 
@@ -621,6 +621,7 @@ PZ saves are single-file-per-world. Two replicas writing to the same PVC would c
 | discordBot.discordToken.existingSecret | string | `""` |  |
 | discordBot.discordToken.existingSecretTokenKey | string | `"discord-token"` |  |
 | discordBot.enabled | bool | `false` |  |
+| discordBot.guildId | string | `""` | Discord server (guild) ID. Not a secret. Guild-scoped command registration is near-instant; leaving this empty falls back to global registration, which can take up to an hour to propagate to clients. |
 | discordBot.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | discordBot.image.repository | string | `"ghcr.io/janip81/zomboid-discord-bot"` | Image repository for zomboid-discord-bot |
 | discordBot.image.tag | string | `"latest"` | Image tag — pin to a SHA or semver tag in production |

--- a/charts/zomboid-server/templates/deployment-discord-bot.yaml
+++ b/charts/zomboid-server/templates/deployment-discord-bot.yaml
@@ -31,6 +31,9 @@ spec:
             {{- if .Values.discordBot.appId }}
             - --discord-app-id={{ .Values.discordBot.appId }}
             {{- end }}
+            {{- if .Values.discordBot.guildId }}
+            - --discord-guild-id={{ .Values.discordBot.guildId }}
+            {{- end }}
             {{- if .Values.exporter.enabled }}
             - --metrics-url=http://{{ include "zomboid-server.fullname" . }}-metrics:{{ .Values.exporter.port }}/metrics
             {{- end }}

--- a/charts/zomboid-server/values.yaml
+++ b/charts/zomboid-server/values.yaml
@@ -272,6 +272,10 @@ discordBot:
   # commands (/online, /serveruptime, /save, /block, /unblock). Empty
   # means slash commands are never registered.
   appId: ""
+  # -- Discord server (guild) ID. Not a secret. Guild-scoped command
+  # registration is near-instant; leaving this empty falls back to global
+  # registration, which can take up to an hour to propagate to clients.
+  guildId: ""
   # -- Admin-tier command access (who can run /save, /block, /unblock) is
   # NOT configured here day-to-day -- it's a Discord-user-ID -> role
   # mapping stored in the discordbot_user_roles table in the same


### PR DESCRIPTION
## Summary
- New `discordBot.guildId` value, passed as `--discord-guild-id` to the bot
- Guild-scoped slash command registration is near-instant vs. global's up-to-1hr propagation delay (confirmed live)

Chart 0.1.12 -> 0.1.13.