### PR TITLE
zomboid-server: add optional debug toggle

### DIFF
--- a/charts/zomboid-server/Chart.yaml
+++ b/charts/zomboid-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zomboid-server
 description: A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 type: application
-version: 0.1.13
+version: 0.1.14
 appVersion: "42.20.2"
 home: https://projectzomboid.com
 icon: https://cdn2.steamgriddb.com/icon/57b7e11eca1be1c2f09e9e9c4cfb9b28/32/256x256.png

--- a/charts/zomboid-server/README.md
+++ b/charts/zomboid-server/README.md
@@ -1,6 +1,6 @@
 # zomboid-server
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 42.20.2](https://img.shields.io/badge/AppVersion-42.20.2-informational?style=flat-square)
+![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 42.20.2](https://img.shields.io/badge/AppVersion-42.20.2-informational?style=flat-square)
 
 A Helm chart for deploying a Project Zomboid dedicated server on Kubernetes
 
@@ -745,6 +745,7 @@ PZ saves are single-file-per-world. Two replicas writing to the same PVC would c
 | zomboid.adminPassword | string | `""` | Admin password (only used for initial account creation; see adminPasswordBootstrap) |
 | zomboid.adminPasswordBootstrap.enabled | bool | `true` | Inject ADMINPASSWORD from the Secret on startup. Set false after the admin account has been created on first run. |
 | zomboid.adminUsername | string | `"admin"` | Admin username |
+| zomboid.debug | bool | `false` | Launches the game server with -debug (isDebugEnabled() true server-side). Off by default -- only intended for disposable test servers, never a real/production instance. |
 | zomboid.displayName | string | `""` | Display name in the server browser (kept from INI if left empty) |
 | zomboid.existingSecret | string | `""` | Reference an existing Kubernetes Secret instead of creating one. The secret must contain the keys defined in secretKeys. Set to "" to have the chart create a secret from the inline password values below. |
 | zomboid.extraEnv | list | `[]` | Additional environment variables passed to the server container |

--- a/charts/zomboid-server/templates/statefulset.yaml
+++ b/charts/zomboid-server/templates/statefulset.yaml
@@ -135,6 +135,10 @@ spec:
             - name: NOSTEAM
               value: "true"
             {{- end }}
+            {{- if .Values.zomboid.debug }}
+            - name: DEBUG
+              value: "true"
+            {{- end }}
             {{- if or .Values.zomboid.selfManagedMods (and (empty .Values.zomboid.mods.workshopIds) (empty .Values.zomboid.mods.modIds)) }}
             # Protect existing INI mod config when no mods are specified in values,
             # or when selfManagedMods is explicitly enabled.

--- a/charts/zomboid-server/values.yaml
+++ b/charts/zomboid-server/values.yaml
@@ -105,6 +105,11 @@ zomboid:
   # -- Allow non-Steam clients to connect
   noSteam: false
 
+  # -- Launches the game server with -debug (isDebugEnabled() true
+  # server-side). Off by default -- only intended for disposable test
+  # servers, never a real/production instance.
+  debug: false
+
   # -- Additional environment variables passed to the server container
   extraEnv: []
   # - name: FORCEUPDATE


### PR DESCRIPTION
## Summary
- Adds `zomboid.debug` (default `false`) to the zomboid-server chart
- Sets `DEBUG=true` on the server container when enabled, which the image's own entrypoint maps to launching with `-debug`
- Off by default -- zero effect on any existing deployment (verified via `helm template`, no `DEBUG` env var rendered unless explicitly set)

## Why
Only intended for disposable test servers (e.g. `zomboid-test`). The panel's own `useDebug` toggle doesn't reliably persist across container restarts. This bakes the flag directly into the launch command instead, avoiding that flakiness entirely for a test instance -- the real production server stays untouched by default.

## Test plan
- [x] `helm lint --strict` passes
- [x] `helm template` with `zomboid.debug=true` renders `DEBUG=true` env var
- [x] `helm template` with default values renders zero `DEBUG` occurrences
- [ ] Set `zomboid.debug: true` in `zomboid-test-app.yaml` values, confirm the test server actually launches with `-debug` and `isDebugEnabled()` returns true

🤖 Generated with [Claude Code](https://claude.com/claude-code)